### PR TITLE
Add Scroll View Content Size Observation

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -72,6 +72,11 @@ public class PanModalPresentationController: UIPresentationController {
      */
     private var scrollObserver: NSKeyValueObservation?
 
+    /**
+     An observer for the scroll view content size
+     */
+    private var scrollContentSizeObserver: NSKeyValueObservation?
+
     // store the y positions so we don't have to keep re-calculating
 
     /**
@@ -161,6 +166,7 @@ public class PanModalPresentationController: UIPresentationController {
 
     deinit {
         scrollObserver?.invalidate()
+        scrollContentSizeObserver?.invalidate()
     }
 
     // MARK: - Lifecycle
@@ -642,8 +648,8 @@ private extension PanModalPresentationController {
 private extension PanModalPresentationController {
 
     /**
-     Creates & stores an observer on the given scroll view's content offset.
-     This allows us to track scrolling without overriding the scrollView delegate
+     Creates & stores an observer on the given scroll view's content offset and content size.
+     This allows us to track scrolling without overriding the scrollView delegate and react to content size changes
      */
     func observe(scrollView: UIScrollView?) {
         scrollObserver?.invalidate()
@@ -657,6 +663,10 @@ private extension PanModalPresentationController {
 
             self?.didPanOnScrollView(scrollView, change: change)
         }
+        scrollContentSizeObserver?.invalidate()
+        scrollContentSizeObserver = scrollView?.observe(\.contentSize, changeHandler: { [weak self] scrollView, change in
+            self?.setNeedsLayoutUpdate()
+        })
     }
 
     /**


### PR DESCRIPTION
###  Summary
Not updating the layout after a scroll view content size change (e.g. from empty to populated state) will result in the inability to scroll.
This PR adds content size observation of the scroll view to the presentation controller.
Whenever the content size changes it will request a layout update.


### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.
