### PR TITLE
Add Intrinsic Height to PanModalHeight

### DIFF
--- a/PanModal/Presentable/PanModalHeight.swift
+++ b/PanModal/Presentable/PanModalHeight.swift
@@ -35,4 +35,8 @@ public enum PanModalHeight: Equatable {
      */
     case contentHeightIgnoringSafeArea(CGFloat)
 
+    /**
+     Sets the height to be the intrinsic content height
+     */
+    case intrinsicHeight
 }

--- a/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
+++ b/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
@@ -90,6 +90,12 @@ extension PanModalPresentable where Self: UIViewController {
             return bottomYPos - (height + bottomLayoutOffset)
         case .contentHeightIgnoringSafeArea(let height):
             return bottomYPos - height
+        case .intrinsicHeight:
+            view.layoutIfNeeded()
+            let targetSize = CGSize(width: (presentingViewController?.view.bounds ?? UIScreen.main.bounds).width,
+                                    height: UIView.layoutFittingCompressedSize.height)
+            let intrinsicHeight = view.systemLayoutSizeFitting(targetSize).height
+            return bottomYPos - (intrinsicHeight + bottomLayoutOffset)
         }
     }
 

--- a/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
+++ b/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
@@ -92,7 +92,7 @@ extension PanModalPresentable where Self: UIViewController {
             return bottomYPos - height
         case .intrinsicHeight:
             view.layoutIfNeeded()
-            let targetSize = CGSize(width: (presentingViewController?.view.bounds ?? UIScreen.main.bounds).width,
+            let targetSize = CGSize(width: (presentedVC?.containerView?.bounds ?? UIScreen.main.bounds).width,
                                     height: UIView.layoutFittingCompressedSize.height)
             let intrinsicHeight = view.systemLayoutSizeFitting(targetSize).height
             return bottomYPos - (intrinsicHeight + bottomLayoutOffset)

--- a/Sample/View Controllers/User Groups (Stacked)/StackedProfileViewController.swift
+++ b/Sample/View Controllers/User Groups (Stacked)/StackedProfileViewController.swift
@@ -85,6 +85,7 @@ class StackedProfileViewController: UIViewController, PanModalPresentable {
 
         roleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         roleLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 4.0).isActive = true
+        bottomLayoutGuide.topAnchor.constraint(greaterThanOrEqualTo: roleLabel.bottomAnchor).isActive = true
     }
 
     // MARK: - Pan Modal Presentable
@@ -94,7 +95,7 @@ class StackedProfileViewController: UIViewController, PanModalPresentable {
     }
 
     var longFormHeight: PanModalHeight {
-        return .contentHeight(300)
+        return .intrinsicHeight
     }
 
     var anchorModalToLongForm: Bool {


### PR DESCRIPTION
###  Summary

This PR adds an `intrinsicHeight` case to the `PanModalHeight` enum.
The StackedProfileViewController has been updated to demonstrate its functionality.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.
