### PR TITLE
Add configurable cornerRadius

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -36,7 +36,6 @@ public class PanModalPresentationController: UIPresentationController {
      Constants
      */
     struct Constants {
-        static let cornerRadius = CGFloat(8.0)
         static let indicatorYOffset = CGFloat(8.0)
         static let snapMovementSensitivity = CGFloat(0.7)
         static let dragIndicatorSize = CGSize(width: 36.0, height: 5.0)
@@ -797,30 +796,16 @@ private extension PanModalPresentationController {
      because we render the dragIndicator outside of view bounds
      */
     func addRoundedCorners(to view: UIView) {
-
-        let path = UIBezierPath()
-        path.move(to: CGPoint(x: 0, y: Constants.cornerRadius))
-
-        // 1. Draw left rounded corner
-        path.addArc(withCenter: CGPoint(x: path.currentPoint.x + Constants.cornerRadius, y: path.currentPoint.y),
-                    radius: Constants.cornerRadius, startAngle: .pi, endAngle: 3.0 * .pi/2.0, clockwise: true)
+        let radius = presentable?.cornerRadius ?? 0
+        let path = UIBezierPath(roundedRect: view.bounds,
+                                byRoundingCorners:[.topRight, .topLeft],
+                                cornerRadii: CGSize(width: radius, height: radius))
 
         // 2. Draw around the drag indicator view, if displayed
         if presentable?.showDragIndicator == true {
             let indicatorLeftEdgeXPos = view.bounds.width/2.0 - Constants.dragIndicatorSize.width/2.0
             drawAroundDragIndicator(currentPath: path, indicatorLeftEdgeXPos: indicatorLeftEdgeXPos)
         }
-
-        // 3. Draw line to right side of presented view, leaving space to draw rounded corner
-        path.addLine(to: CGPoint(x: view.bounds.width - Constants.cornerRadius, y: path.currentPoint.y))
-
-        // 4. Draw right rounded corner
-        path.addArc(withCenter: CGPoint(x: path.currentPoint.x, y: path.currentPoint.y + Constants.cornerRadius),
-                    radius: Constants.cornerRadius, startAngle: 3.0 * .pi/2.0, endAngle: 0, clockwise: true)
-
-        // 5. Draw around final edges of view
-        path.addLine(to: CGPoint(x: path.currentPoint.x, y: view.bounds.height))
-        path.addLine(to: CGPoint(x: 0, y: path.currentPoint.y))
 
         // 6. Set path as a mask to display optional drag indicator view & rounded corners
         let mask = CAShapeLayer()

--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -798,10 +798,10 @@ private extension PanModalPresentationController {
     func addRoundedCorners(to view: UIView) {
         let radius = presentable?.cornerRadius ?? 0
         let path = UIBezierPath(roundedRect: view.bounds,
-                                byRoundingCorners:[.topRight, .topLeft],
+                                byRoundingCorners: [.topRight, .topLeft],
                                 cornerRadii: CGSize(width: radius, height: radius))
 
-        // 2. Draw around the drag indicator view, if displayed
+        // Draw around the drag indicator view, if displayed
         if presentable?.showDragIndicator == true {
             let indicatorLeftEdgeXPos = view.bounds.width/2.0 - Constants.dragIndicatorSize.width/2.0
             drawAroundDragIndicator(currentPath: path, indicatorLeftEdgeXPos: indicatorLeftEdgeXPos)

--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -798,7 +798,7 @@ private extension PanModalPresentationController {
     func addRoundedCorners(to view: UIView) {
         let radius = presentable?.cornerRadius ?? 0
         let path = UIBezierPath(roundedRect: view.bounds,
-                                byRoundingCorners: [.topRight, .topLeft],
+                                byRoundingCorners: [.topLeft, .topRight],
                                 cornerRadii: CGSize(width: radius, height: radius))
 
         // Draw around the drag indicator view, if displayed

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -40,7 +40,7 @@ public extension PanModalPresentable where Self: UIViewController {
     }
 
     var scrollIndicatorInsets: UIEdgeInsets {
-        let top = shouldRoundTopCorners ? PanModalPresentationController.Constants.cornerRadius : 0
+        let top = shouldRoundTopCorners ? cornerRadius : 0
         return UIEdgeInsets(top: CGFloat(top), left: 0, bottom: bottomLayoutOffset, right: 0)
     }
 
@@ -75,6 +75,10 @@ public extension PanModalPresentable where Self: UIViewController {
 
     var shouldRoundTopCorners: Bool {
         return isPanModalPresented
+    }
+
+    var cornerRadius: CGFloat {
+        return 8
     }
 
     var showDragIndicator: Bool {

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -138,6 +138,13 @@ public protocol PanModalPresentable {
     var shouldRoundTopCorners: Bool { get }
 
     /**
+     The corner radius used when `shouldRoundTopCorners` is enabled.
+     
+     Default Value is `8.0`
+     */
+    var cornerRadius: CGFloat { get }
+
+    /**
      A flag to determine if a drag indicator should be shown
      above the pan modal container view.
 

--- a/Tests/PanModalTests.swift
+++ b/Tests/PanModalTests.swift
@@ -59,6 +59,7 @@ class PanModalTests: XCTestCase {
         XCTAssertEqual(vc.shouldRoundTopCorners, false)
         XCTAssertEqual(vc.showDragIndicator, false)
         XCTAssertEqual(vc.shouldRoundTopCorners, false)
+        XCTAssertEqual(vc.cornerRadius, 8)
     }
 
     func testPresentableYValues() {


### PR DESCRIPTION
###  Summary

This PR adds support for letting any `PanModalPresentable` set the desired corner radius on the modal.
It also simplifies how the mask path is created.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.
