### PR TITLE
Replace `isPanScrollEnabled` with `shouldRespond(to ..`

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -414,7 +414,6 @@ private extension PanModalPresentationController {
          to avoid visual bugs
          */
         scrollView.showsVerticalScrollIndicator = false
-        scrollView.isScrollEnabled = presentable?.isPanScrollEnabled ?? true
         scrollView.scrollIndicatorInsets = presentable?.scrollIndicatorInsets ?? .zero
 
         /**
@@ -444,8 +443,7 @@ private extension PanModalPresentationController {
     @objc func didPanOnPresentedView(_ recognizer: UIPanGestureRecognizer) {
 
         guard
-            presentable?.isPanScrollEnabled == true,
-            !shouldFail(panGestureRecognizer: recognizer),
+            shouldRespond(to: panGestureRecognizer),
             let containerView = containerView
             else {
                 recognizer.setTranslation(.zero, in: recognizer.view)
@@ -513,6 +511,26 @@ private extension PanModalPresentationController {
                 }
             }
         }
+    }
+
+    /**
+     Determine if the pan modal should respond to the gesture recognizer.
+
+     If the pan modal is already being dragged & the delegate returns false, ignore until
+     the recognizer is back to it's original state (.began)
+
+     ⚠️ This is the only time we should be cancelling the pan modal gesture recognizer
+     */
+    func shouldRespond(to panGestureRecognizer: UIPanGestureRecognizer) -> Bool {
+        guard
+            presentable?.shouldRespond(to: panGestureRecognizer) == true ||
+                !(panGestureRecognizer.state == .began || panGestureRecognizer.state == .cancelled)
+            else {
+                panGestureRecognizer.isEnabled = false
+                panGestureRecognizer.isEnabled = true
+                return false
+        }
+        return !shouldFail(panGestureRecognizer: panGestureRecognizer)
     }
 
     /**

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -64,10 +64,6 @@ public extension PanModalPresentable where Self: UIViewController {
         return true
     }
 
-    var isPanScrollEnabled: Bool {
-        return true
-    }
-
     var isUserInteractionEnabled: Bool {
         return true
     }
@@ -84,7 +80,11 @@ public extension PanModalPresentable where Self: UIViewController {
         return shouldRoundTopCorners
     }
 
-    func willRespond(to panGestureRecognizer: UIPanGestureRecognizer) {
+    func shouldRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {
+        return false
+    }
+
+    func willRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) {
 
     }
 

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -81,7 +81,7 @@ public extension PanModalPresentable where Self: UIViewController {
     }
 
     func shouldRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {
-        return false
+        return true
     }
 
     func willRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) {

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -112,16 +112,6 @@ public protocol PanModalPresentable {
     var allowsDragToDismiss: Bool { get }
 
     /**
-     A flag to determine if scrolling should be enabled on the entire view.
-
-     - Note: Returning false will disable scrolling on the embedded scrollview as well as on the
-     pan modal container view.
-
-     Default value is true.
-     */
-    var isPanScrollEnabled: Bool { get }
-
-    /**
      A flag to toggle user interactions on the container view.
 
      - Note: Return false to forward touches to the presentingViewController.
@@ -151,6 +141,15 @@ public protocol PanModalPresentable {
      Default value is true.
      */
     var showDragIndicator: Bool { get }
+
+    /**
+     Asks the delegate if the pan modal should respond to the pan modal gesture recognizer.
+     
+     Return false to disable movement on the pan modal but maintain gestures on the presented view.
+
+     Default value is true.
+     */
+    func shouldRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool
 
     /**
      Notifies the delegate when the pan modal gesture recognizer state is either

--- a/Tests/PanModalTests.swift
+++ b/Tests/PanModalTests.swift
@@ -53,7 +53,6 @@ class PanModalTests: XCTestCase {
         XCTAssertEqual(vc.anchorModalToLongForm, true)
         XCTAssertEqual(vc.allowsExtendedPanScrolling, false)
         XCTAssertEqual(vc.allowsDragToDismiss, true)
-        XCTAssertEqual(vc.isPanScrollEnabled, true)
         XCTAssertEqual(vc.isUserInteractionEnabled, true)
         XCTAssertEqual(vc.isHapticFeedbackEnabled, true)
         XCTAssertEqual(vc.shouldRoundTopCorners, false)


### PR DESCRIPTION
- Replace `isPanScrollEnabled` with `func shouldRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool`, this would allow for specific views to ignore touches to the outer modal e.g. in the case of UIPickerView
