### PR TITLE
Correct some docs typos

### DIFF
--- a/PanModal/Animator/PanModalPresentationAnimator.swift
+++ b/PanModal/Animator/PanModalPresentationAnimator.swift
@@ -124,7 +124,7 @@ extension PanModalPresentationAnimator: UIViewControllerAnimatedTransitioning {
     }
 
     /**
-     Perfroms the appropriate animation based on the transition style
+     Performs the appropriate animation based on the transition style
      */
     public func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         switch transitionStyle {

--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -220,7 +220,7 @@ public class PanModalPresentationController: UIPresentationController {
 public extension PanModalPresentationController {
 
     /**
-     Tranisition the PanModalPresentationController
+     Transition the PanModalPresentationController
      to the given presentation state
      */
     public func transition(to state: PresentationState) {
@@ -384,7 +384,7 @@ private extension PanModalPresentationController {
     }
 
     /**
-     Caluclates & stores the layout anchor points & options
+     Calculates & stores the layout anchor points & options
      */
     func configureViewLayout() {
 

--- a/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
+++ b/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
@@ -38,7 +38,7 @@ extension PanModalPresentable where Self: UIViewController {
     }
 
     /**
-     Returns the short form Y postion
+     Returns the short form Y position
 
      - Note: If voiceover is on, the `longFormYPos` is returned.
      We do not support short form when voiceover is on as it would make it difficult for user to navigate.
@@ -55,7 +55,7 @@ extension PanModalPresentable where Self: UIViewController {
     }
 
     /**
-     Returns the long form Y postion
+     Returns the long form Y position
 
      - Note: We cap this value to the max possible height
      to ensure content is not rendered outside of the view bounds


### PR DESCRIPTION
###  Summary

This PR corrects some typos in the documentations

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.
