### PR TITLE
Adding functionality for UIViewController appearance callback forwarding

### DIFF
--- a/PanModal/Animator/PanModalPresentationAnimator.swift
+++ b/PanModal/Animator/PanModalPresentationAnimator.swift
@@ -63,11 +63,15 @@ public class PanModalPresentationAnimator: NSObject {
      */
     private func animatePresentation(transitionContext: UIViewControllerContextTransitioning) {
 
-        guard let toVC = transitionContext.viewController(forKey: .to)
+        guard let toVC = transitionContext.viewController(forKey: .to), let fromVC = transitionContext.viewController(forKey: .from)
             else { return }
 
         let presentable = toVC as? PanModalPresentable.LayoutType
 
+        // Calls viewWillAppear and viewWillDisappear
+        fromVC.beginAppearanceTransition(false, animated: true)
+        toVC.beginAppearanceTransition(true, animated: true)
+        
         // Presents the view in shortForm position, initially
         let yPos: CGFloat = presentable?.shortFormYPos ?? 0.0
 
@@ -86,6 +90,9 @@ public class PanModalPresentationAnimator: NSObject {
         PanModalAnimator.animate({
             panView.frame.origin.y = yPos
         }, config: presentable) { [weak self] didComplete in
+            // Calls viewDidAppear and viewDidDisappear
+            fromVC.endAppearanceTransition()
+            toVC.endAppearanceTransition()
             transitionContext.completeTransition(didComplete)
             self?.feedbackGenerator = nil
         }
@@ -96,9 +103,13 @@ public class PanModalPresentationAnimator: NSObject {
      */
     private func animateDismissal(transitionContext: UIViewControllerContextTransitioning) {
 
-        guard let fromVC = transitionContext.viewController(forKey: .from)
+        guard let fromVC = transitionContext.viewController(forKey: .from), let toVC = transitionContext.viewController(forKey: .to)
             else { return }
 
+        // Calls viewWillAppear and viewWillDisappear
+        fromVC.beginAppearanceTransition(false, animated: true)
+        toVC.beginAppearanceTransition(true, animated: true)
+        
         let presentable = fromVC as? PanModalPresentable.LayoutType
         let panView: UIView = transitionContext.containerView.panContainerView ?? fromVC.view
 
@@ -106,6 +117,9 @@ public class PanModalPresentationAnimator: NSObject {
             panView.frame.origin.y = transitionContext.containerView.frame.height
         }, config: presentable) { didComplete in
             fromVC.view.removeFromSuperview()
+            // Calls viewDidAppear and viewDidDisappear
+            fromVC.endAppearanceTransition()
+            toVC.endAppearanceTransition()
             transitionContext.completeTransition(didComplete)
         }
     }


### PR DESCRIPTION
Resolves #20

###  Summary

Appearance callbacks were missing because the view controller is presented with a `.custom` `modalPresentationStyle`, so the `PanModalPresentationAnimator` is in charge of making the appropriate calls as necessary (before animating, after animating).

When presenting the modal view controller:
* `viewWillDisappear`, `viewDidDisappear` is called on the view controller when presenting the modal view controller.
* `viewWillAppear`, `viewDidAppear` is called on the presented modal view controller.

When dismissing the modal view controller:
* `viewWillDisappear`, `viewDidDisappear` is called on the presented modal view controller.
* `viewWillAppear`, `viewDidAppear` is called on the view controller presenting the modal.

If you would like to test this, you can add the following to the `SampleViewController` and any of the presented view controllers in the demo app and view the appropriate appearance calls being made before, during and after the presenting and dismissing presentations.

```swift
override func viewWillAppear(_ animated: Bool) {
    super.viewWillAppear(animated)
    print(self)
    print(#function)
}

override func viewDidAppear(_ animated: Bool) {
    super.viewDidAppear(animated)
    print(self)
    print(#function)
}

override func viewWillDisappear(_ animated: Bool) {
    super.viewWillDisappear(animated)
    print(self)
    print(#function)
}

override func viewDidDisappear(_ animated: Bool) {
    super.viewDidAppear(animated)
    print(self)
    print(#function)
}
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.