### PR TITLE
Ability to show on iPad as PanModal

### DIFF
--- a/PanModal.podspec
+++ b/PanModal.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'PanModal'
-  s.version          = '1.2.2'
+  s.version          = '1.3.0'
   s.summary          = 'PanModal is an elegant and highly customizable presentation API for constructing bottom sheet modals on iOS.'
 
 # This description is used to generate tags and improve search results.

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -71,6 +71,10 @@ public extension PanModalPresentable where Self: UIViewController {
     var allowsDragToDismiss: Bool {
         return true
     }
+    
+    var alwaysForcePanModal: Bool {
+        return false
+    }
 
     var isUserInteractionEnabled: Bool {
         return true

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -126,6 +126,15 @@ public protocol PanModalPresentable: AnyObject {
      Default value is true.
      */
     var allowsDragToDismiss: Bool { get }
+    
+    /**
+     A flag to determine if a pan modal should be used on iPad or UIPopover
+     
+     - Note: Return true to use always use a pan modal
+     
+     Default is false.
+     */
+    var alwaysForcePanModal: Bool { get }
 
     /**
      A flag to toggle user interactions on the container view.

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -128,11 +128,11 @@ public protocol PanModalPresentable: AnyObject {
     var allowsDragToDismiss: Bool { get }
     
     /**
-     A flag to determine if a pan modal should be used on iPad or UIPopover
+     A flag to determine if the UIViewController should always be presented as Pan Modal.
      
-     - Note: Return true to use always use a pan modal
+     - Note: Return true to always be a Pan Modal
      
-     Default is false.
+     Default is false. Which means that on iPad, it will be presented as a popover & as Pan Modal on iPhone.
      */
     var alwaysForcePanModal: Bool { get }
 

--- a/PanModal/Presenter/UIViewController+PanModalPresenter.swift
+++ b/PanModal/Presenter/UIViewController+PanModalPresenter.swift
@@ -43,7 +43,7 @@ extension UIViewController: PanModalPresenter {
          Here, we deliberately do not check for size classes. More info in `PanModalPresentationDelegate`
          */
 
-        if UIDevice.current.userInterfaceIdiom == .pad {
+        if UIDevice.current.userInterfaceIdiom == .pad && !viewControllerToPresent.alwaysForcePanModal {
             viewControllerToPresent.modalPresentationStyle = .popover
             viewControllerToPresent.popoverPresentationController?.sourceRect = sourceRect
             viewControllerToPresent.popoverPresentationController?.sourceView = sourceView ?? view


### PR DESCRIPTION
###  Summary
In some cases, it might be useful to have the ability to present an `UIViewController` as a pan modal instead of a popover on iPad.
Since it's just a few lines of code & logic, I decided to open a Pull Request without an Issue.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.

Regarding this last one, I don't think there's much value in adding a UT to this feature or if it's even feasible. What would be cool since it's a UI framework, would be to add snapshot tests in the future.