### PR TITLE
Added the ability to select a style for the background of the pan mod…

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -2,6 +2,7 @@
 //  PanModalPresentationController.swift
 //  PanModal
 //
+//  Updated by Nikita Nikitsky on 16/08/2019.
 //  Copyright © 2019 Tiny Speck, Inc. All rights reserved.
 //
 
@@ -105,10 +106,17 @@ public class PanModalPresentationController: UIPresentationController {
      */
     private lazy var backgroundView: DimmedView = {
         let view: DimmedView
-        if let alpha = presentable?.backgroundAlpha {
-            view = DimmedView(dimAlpha: alpha)
-        } else {
-            view = DimmedView()
+        switch presentable?.backgroundStyle {
+        case let .solid(color, alpha)?:
+            view = SolidDimmedView(color: color, alpha: alpha)
+        case let .gradient(colors, startPoint, endPoint, type, alpha)?:
+            view = GradientDimmedView(colors: colors, startPoint: startPoint, endPoint: endPoint, type: type, alpha: alpha)
+        case let .blur(style, degree)?:
+            view = BlurDimmedView(style: style, degree: degree)
+        case let .custom(dimmedView)?:
+            view = dimmedView
+        default:
+            view = SolidDimmedView(color: .black, alpha: 0.7)
         }
         view.didTap = { [weak self] _ in
             self?.dismissPresentedViewController()
@@ -653,7 +661,7 @@ private extension PanModalPresentationController {
 
         /**
          Once presentedView is translated below shortForm, calculate yPos relative to bottom of screen
-         and apply percentage to backgroundView alpha
+         and apply percentage to backgroundView state
          */
         backgroundView.dimState = .percent(1.0 - (yDisplacementFromShortForm / presentedView.frame.height))
     }

--- a/PanModal/Presentable/PanModalBackgroundStyle.swift
+++ b/PanModal/Presentable/PanModalBackgroundStyle.swift
@@ -1,0 +1,101 @@
+//
+//  PanModalBackgroundStyle.swift
+//  PanModal
+//
+//  Created by Nikita Nikitsky on 16/08/2019.
+//  Copyright © 2017 Tiny Speck, Inc. All rights reserved.
+//
+
+import UIKit
+
+/**
+ An enum that defines the possible styles of the background of a pan modal container view.
+ */
+public enum PanModalBackgroundStyle: Equatable {
+
+    /**
+     An enum that defines the possible value of the point of the gradient
+     when drawn into the layer's coordinate space
+     */
+    public enum Point {
+        case topLeft
+        case centerLeft
+        case bottomLeft
+        case topCenter
+        case center
+        case bottomCenter
+        case topRight
+        case centerRight
+        case bottomRight
+        case custom(CGPoint)
+
+        var cgPoint: CGPoint {
+            switch self {
+            case .topLeft:
+                return CGPoint(x: 0, y: 0)
+            case .centerLeft:
+                return CGPoint(x: 0, y: 0.5)
+            case .bottomLeft:
+                return CGPoint(x: 0, y: 1.0)
+            case .topCenter:
+                return CGPoint(x: 0.5, y: 0)
+            case .center:
+                return CGPoint(x: 0.5, y: 0.5)
+            case .bottomCenter:
+                return CGPoint(x: 0.5, y: 1.0)
+            case .topRight:
+                return CGPoint(x: 1.0, y: 0.0)
+            case .centerRight:
+                return CGPoint(x: 1.0, y: 0.5)
+            case .bottomRight:
+                return CGPoint(x: 1.0, y: 1.0)
+            case let .custom(cgPoint):
+                return cgPoint
+            }
+        }
+    }
+
+    /**
+     Sets the backgound style to be the solid color effect with specified alpha.
+     */
+    case solid(color: UIColor, alpha: CGFloat)
+
+    /**
+     Sets the backgound style to be the color gradient effect
+     with specified start point of the gradient, end point of the gradient,
+     gradient type and alpha.
+     */
+    case gradient(colors: [UIColor], startPoint: Point, endPoint: Point, type: CAGradientLayerType, alpha: CGFloat)
+
+    /**
+     Sets the background style to be the blur effect
+     with specified the blur style and degree.
+     */
+    case blur(style: UIBlurEffect.Style, degree: CGFloat)
+
+    /**
+     Sets the background style to be the custom effect
+     specified by user.
+     */
+    case custom(DimmedView)
+
+    public static func == (lhs: PanModalBackgroundStyle, rhs: PanModalBackgroundStyle) -> Bool {
+        switch (lhs, rhs) {
+        case let (.solid(lhsColor, lhsAlpha), .solid(rhsColor, rhsAlpha)):
+            return lhsColor == rhsColor &&
+                   lhsAlpha == rhsAlpha
+        case let (.gradient(lhsColors, lhsStartPoint, lhsEndPoint, lhsType, lhsAlpha), .gradient(rhsColors, rhsStartPoint, rhsEndPoint, rhsType, rhsAlpha)):
+            return lhsColors == rhsColors &&
+                   lhsStartPoint.cgPoint == rhsStartPoint.cgPoint &&
+                   lhsEndPoint.cgPoint == rhsEndPoint.cgPoint &&
+                   lhsType == rhsType &&
+                   lhsAlpha == rhsAlpha
+        case let (.blur(lhsType, lhsDegree), .blur(rhsType, rhsDegree)):
+            return lhsType == rhsType &&
+                   lhsDegree == rhsDegree
+        default:
+            return false
+        }
+    }
+
+}

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -2,6 +2,7 @@
 //  PanModalPresentable+Defaults.swift
 //  PanModal
 //
+//  Updated by Nikita Nikitsky on 16/08/2019.
 //  Copyright © 2018 Tiny Speck, Inc. All rights reserved.
 //
 
@@ -48,6 +49,10 @@ public extension PanModalPresentable where Self: UIViewController {
 
     var backgroundAlpha: CGFloat {
         return 0.7
+    }
+
+    var backgroundStyle: PanModalBackgroundStyle {
+        return .solid(color: .black, alpha: 0.7)
     }
 
     var scrollIndicatorInsets: UIEdgeInsets {

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -2,6 +2,7 @@
 //  PanModalPresentable.swift
 //  PanModal
 //
+//  Updated by Nikita Nikitsky on 16/08/2019.
 //  Copyright © 2017 Tiny Speck, Inc. All rights reserved.
 //
 
@@ -92,7 +93,17 @@ public protocol PanModalPresentable: AnyObject {
 
      Default Value is 0.7.
      */
+    @available(*, deprecated, message: "Replace to the background style.")
     var backgroundAlpha: CGFloat { get }
+
+    /**
+     The background view style.
+
+     - Note: This is only utilized at the very start of the transition.
+
+     Default Value is solid black with alpha 0.7.
+     */
+    var backgroundStyle: PanModalBackgroundStyle { get }
 
     /**
      We configure the panScrollable's scrollIndicatorInsets interally so override this value

--- a/PanModal/View/BlurDimmedView.swift
+++ b/PanModal/View/BlurDimmedView.swift
@@ -1,0 +1,72 @@
+//
+//  BlurDimmedView.swift
+//  PanModal
+//
+//  Created by Nikita Nikitsky on 16/08/2019.
+//  Copyright © 2017 Tiny Speck, Inc. All rights reserved.
+//
+
+import UIKit
+
+/**
+ A dim view with blur effect for use as an overlay over content you want dimmed.
+ */
+class BlurDimmedView: UIVisualEffectView, DimmedView {
+
+    // MARK: - Properties
+
+    var dimState: DimState = .off {
+        didSet {
+            switch dimState {
+            case .max:
+                animator.fractionComplete = blurDegree
+            case .off:
+                animator.fractionComplete = 0.0
+            case .percent(let percentage):
+                let val = max(0.0, min(1.0, percentage))
+                animator.fractionComplete = val * blurDegree
+            }
+        }
+    }
+
+    var didTap: ((_ recognizer: UIGestureRecognizer) -> Void)?
+
+    /**
+     Tap gesture recognizer
+     */
+    private lazy var tapGesture: UIGestureRecognizer = {
+        return UITapGestureRecognizer(target: self, action: #selector(didTapView))
+    }()
+
+    private let blurDegree: CGFloat
+    private var animator: UIViewPropertyAnimator!
+
+    // MARK: - Initializers
+
+    init(style: UIBlurEffect.Style, degree: CGFloat) {
+        self.blurDegree = degree
+        super.init(effect: nil)
+        animator = UIViewPropertyAnimator(duration: 1.0, curve: .linear) {
+            self.effect = UIBlurEffect(style: style)
+        }
+        addGestureRecognizer(tapGesture)
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError()
+    }
+
+    // MARK: - Deinitializer
+
+    deinit {
+        animator.stopAnimation(true)
+    }
+
+    // MARK: - Event Handlers
+
+    @objc private func didTapView() {
+        animator.fractionComplete = 0.0
+        didTap?(tapGesture)
+    }
+
+}

--- a/PanModal/View/DimmedView.swift
+++ b/PanModal/View/DimmedView.swift
@@ -2,77 +2,35 @@
 //  DimmedView.swift
 //  PanModal
 //
+//  Updated by Nikita Nikitsky on 16/08/2019.
 //  Copyright © 2017 Tiny Speck, Inc. All rights reserved.
 //
 
 import UIKit
 
 /**
+ Represents the possible states of the dimmed view.
+ max, off or a percentage of effect applied.
+ */
+public enum DimState {
+    case max
+    case off
+    case percent(CGFloat)
+}
+
+/**
  A dim view for use as an overlay over content you want dimmed.
  */
-public class DimmedView: UIView {
-
-    /**
-     Represents the possible states of the dimmed view.
-     max, off or a percentage of dimAlpha.
-     */
-    enum DimState {
-        case max
-        case off
-        case percent(CGFloat)
-    }
-
-    // MARK: - Properties
+public protocol DimmedView: UIView {
 
     /**
      The state of the dimmed view
      */
-    var dimState: DimState = .off {
-        didSet {
-            switch dimState {
-            case .max:
-                alpha = dimAlpha
-            case .off:
-                alpha = 0.0
-            case .percent(let percentage):
-                let val = max(0.0, min(1.0, percentage))
-                alpha = dimAlpha * val
-            }
-        }
-    }
+    var dimState: DimState { get set }
 
     /**
      The closure to be executed when a tap occurs
      */
-    var didTap: ((_ recognizer: UIGestureRecognizer) -> Void)?
-
-    /**
-     Tap gesture recognizer
-     */
-    private lazy var tapGesture: UIGestureRecognizer = {
-        return UITapGestureRecognizer(target: self, action: #selector(didTapView))
-    }()
-
-    private let dimAlpha: CGFloat
-
-    // MARK: - Initializers
-
-    init(dimAlpha: CGFloat = 0.7) {
-        self.dimAlpha = dimAlpha
-        super.init(frame: .zero)
-        alpha = 0.0
-        backgroundColor = .black
-        addGestureRecognizer(tapGesture)
-    }
-
-    required public init?(coder aDecoder: NSCoder) {
-        fatalError()
-    }
-
-    // MARK: - Event Handlers
-
-    @objc private func didTapView() {
-        didTap?(tapGesture)
-    }
+    var didTap: ((_ recognizer: UIGestureRecognizer) -> Void)? { get set }
 
 }

--- a/PanModal/View/GradientDimmedView.swift
+++ b/PanModal/View/GradientDimmedView.swift
@@ -1,0 +1,82 @@
+//
+//  BlurDimmedView.swift
+//  PanModal
+//
+//  Created by Nikita Nikitsky on 16/08/2019.
+//  Copyright © 2017 Tiny Speck, Inc. All rights reserved.
+//
+
+import UIKit
+
+/**
+ A dim view with color gradient effect for use as an overlay over content you want dimmed.
+ */
+class GradientDimmedView: UIView, DimmedView {
+
+    // MARK: - Properties
+
+    var dimState: DimState = .off {
+        didSet {
+            switch dimState {
+            case .max:
+                animator.fractionComplete = dimAlpha
+            case .off:
+                animator.fractionComplete = 0.0
+            case .percent(let percentage):
+                let val = max(0.0, min(1.0, percentage))
+                animator.fractionComplete = val * dimAlpha
+            }
+        }
+    }
+
+    var didTap: ((_ recognizer: UIGestureRecognizer) -> Void)?
+
+    /**
+     Tap gesture recognizer
+     */
+    private lazy var tapGesture: UIGestureRecognizer = {
+        return UITapGestureRecognizer(target: self, action: #selector(didTapView))
+    }()
+
+    private let dimAlpha: CGFloat
+    private var animator: UIViewPropertyAnimator!
+
+    override class var layerClass: AnyClass {
+        return CAGradientLayer.self
+    }
+
+    // MARK: - Initializers
+
+    init(colors: [UIColor], startPoint: PanModalBackgroundStyle.Point, endPoint: PanModalBackgroundStyle.Point, type: CAGradientLayerType, alpha: CGFloat) {
+        dimAlpha = alpha
+        super.init(frame: .zero)
+        let gradientLayer = layer as? CAGradientLayer
+        gradientLayer?.colors = colors.map({ $0.cgColor })
+        gradientLayer?.startPoint = startPoint.cgPoint
+        gradientLayer?.endPoint = endPoint.cgPoint
+        gradientLayer?.type = type
+        animator = UIViewPropertyAnimator(duration: 1.0, curve: .linear) {
+            self.alpha = 1.0
+        }
+        self.alpha = 0.0
+        addGestureRecognizer(tapGesture)
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError()
+    }
+
+    // MARK: - Deinitializer
+
+    deinit {
+        animator.stopAnimation(true)
+    }
+
+    // MARK: - Event Handlers
+
+    @objc private func didTapView() {
+        animator.fractionComplete = 0.0
+        didTap?(tapGesture)
+    }
+
+}

--- a/PanModal/View/SolidDimmedView.swift
+++ b/PanModal/View/SolidDimmedView.swift
@@ -1,0 +1,74 @@
+//
+//  BlurDimmedView.swift
+//  PanModal
+//
+//  Created by Nikita Nikitsky on 16/08/2019.
+//  Copyright © 2017 Tiny Speck, Inc. All rights reserved.
+//
+
+import UIKit
+
+/**
+ A dim view with solid color effect for use as an overlay over content you want dimmed.
+ */
+class SolidDimmedView: UIView, DimmedView {
+
+    // MARK: - Properties
+
+    var dimState: DimState = .off {
+        didSet {
+            switch dimState {
+            case .max:
+                animator.fractionComplete = dimAlpha
+            case .off:
+                animator.fractionComplete = 0.0
+            case .percent(let percentage):
+                let val = max(0.0, min(1.0, percentage))
+                animator.fractionComplete = val * dimAlpha
+            }
+        }
+    }
+
+    var didTap: ((_ recognizer: UIGestureRecognizer) -> Void)?
+
+    /**
+     Tap gesture recognizer
+     */
+    private lazy var tapGesture: UIGestureRecognizer = {
+        return UITapGestureRecognizer(target: self, action: #selector(didTapView))
+    }()
+
+    private let dimAlpha: CGFloat
+    private var animator: UIViewPropertyAnimator!
+
+    // MARK: - Initializers
+
+    init(color: UIColor, alpha: CGFloat) {
+        dimAlpha = alpha
+        super.init(frame: .zero)
+        animator = UIViewPropertyAnimator(duration: 1.0, curve: .linear) {
+            self.alpha = 1.0
+        }
+        backgroundColor = color
+        self.alpha = 0.0
+        addGestureRecognizer(tapGesture)
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError()
+    }
+
+    // MARK: - Deinitializer
+
+    deinit {
+        animator.stopAnimation(true)
+    }
+
+    // MARK: - Event Handlers
+
+    @objc private func didTapView() {
+        animator.fractionComplete = 0.0
+        didTap?(tapGesture)
+    }
+
+}

--- a/PanModalDemo.xcodeproj/project.pbxproj
+++ b/PanModalDemo.xcodeproj/project.pbxproj
@@ -44,6 +44,14 @@
 		944EBA2E227BB7F400C4C97B /* FullScreenNavController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944EBA2D227BB7F400C4C97B /* FullScreenNavController.swift */; };
 		94795C9B21F0335D008045A0 /* PanModalPresentationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94795C9A21F0335D008045A0 /* PanModalPresentationDelegate.swift */; };
 		94795C9D21F03368008045A0 /* PanContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94795C9C21F03368008045A0 /* PanContainerView.swift */; };
+		CC49554F22FD26D000D168EB /* SolidDimmedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC49554E22FD26D000D168EB /* SolidDimmedView.swift */; };
+		CC49555022FD270100D168EB /* SolidDimmedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC49554E22FD26D000D168EB /* SolidDimmedView.swift */; };
+		CC49555222FD301100D168EB /* PanModalBackgroundStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC49555122FD301100D168EB /* PanModalBackgroundStyle.swift */; };
+		CC49555322FD31E700D168EB /* PanModalBackgroundStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC49555122FD301100D168EB /* PanModalBackgroundStyle.swift */; };
+		CC49555522FD36C100D168EB /* GradientDimmedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC49555422FD36C100D168EB /* GradientDimmedView.swift */; };
+		CC49555622FD36DF00D168EB /* GradientDimmedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC49555422FD36C100D168EB /* GradientDimmedView.swift */; };
+		CCC8F4BB22FDC54E00F2A481 /* BlurDimmedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC8F4BA22FDC54E00F2A481 /* BlurDimmedView.swift */; };
+		CCC8F4BC22FDC6DF00F2A481 /* BlurDimmedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCC8F4BA22FDC54E00F2A481 /* BlurDimmedView.swift */; };
 		DC13905E216D90D5007A3E64 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC13905D216D90D5007A3E64 /* Assets.xcassets */; };
 		DC139061216D93ED007A3E64 /* SampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC139060216D93ED007A3E64 /* SampleViewController.swift */; };
 		DC139070216D9458007A3E64 /* PanModalPresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC139066216D9458007A3E64 /* PanModalPresentationAnimator.swift */; };
@@ -116,6 +124,10 @@
 		944EBA2D227BB7F400C4C97B /* FullScreenNavController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenNavController.swift; sourceTree = "<group>"; };
 		94795C9A21F0335D008045A0 /* PanModalPresentationDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PanModalPresentationDelegate.swift; sourceTree = "<group>"; };
 		94795C9C21F03368008045A0 /* PanContainerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PanContainerView.swift; sourceTree = "<group>"; };
+		CC49554E22FD26D000D168EB /* SolidDimmedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SolidDimmedView.swift; sourceTree = "<group>"; };
+		CC49555122FD301100D168EB /* PanModalBackgroundStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanModalBackgroundStyle.swift; sourceTree = "<group>"; };
+		CC49555422FD36C100D168EB /* GradientDimmedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientDimmedView.swift; sourceTree = "<group>"; };
+		CCC8F4BA22FDC54E00F2A481 /* BlurDimmedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurDimmedView.swift; sourceTree = "<group>"; };
 		DC13905D216D90D5007A3E64 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		DC139060216D93ED007A3E64 /* SampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleViewController.swift; sourceTree = "<group>"; };
 		DC139066216D9458007A3E64 /* PanModalPresentationAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PanModalPresentationAnimator.swift; sourceTree = "<group>"; };
@@ -300,6 +312,7 @@
 			isa = PBXGroup;
 			children = (
 				74C072A4220BA76D00124CE1 /* PanModalHeight.swift */,
+				CC49555122FD301100D168EB /* PanModalBackgroundStyle.swift */,
 				DC139068216D9458007A3E64 /* PanModalPresentable.swift */,
 				DCC0EE7B21917F2500208DBC /* PanModalPresentable+Defaults.swift */,
 				DC139069216D9458007A3E64 /* PanModalPresentable+UIViewController.swift */,
@@ -320,6 +333,9 @@
 			isa = PBXGroup;
 			children = (
 				DC13906E216D9458007A3E64 /* DimmedView.swift */,
+				CC49554E22FD26D000D168EB /* SolidDimmedView.swift */,
+				CC49555422FD36C100D168EB /* GradientDimmedView.swift */,
+				CCC8F4BA22FDC54E00F2A481 /* BlurDimmedView.swift */,
 				94795C9C21F03368008045A0 /* PanContainerView.swift */,
 			);
 			path = View;
@@ -531,6 +547,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CC49555222FD301100D168EB /* PanModalBackgroundStyle.swift in Sources */,
 				0F2A2C5E2239C137003BDB2F /* PanModalAnimator.swift in Sources */,
 				0F2A2C5F2239C139003BDB2F /* PanModalPresentationAnimator.swift in Sources */,
 				0F2A2C602239C13C003BDB2F /* PanModalPresentationController.swift in Sources */,
@@ -542,8 +559,11 @@
 				0F2A2C662239C153003BDB2F /* PanModalPresentable+LayoutHelpers.swift in Sources */,
 				0F2A2C672239C157003BDB2F /* PanModalPresenter.swift in Sources */,
 				0F2A2C682239C15D003BDB2F /* UIViewController+PanModalPresenter.swift in Sources */,
+				CC49555522FD36C100D168EB /* GradientDimmedView.swift in Sources */,
 				0F2A2C692239C162003BDB2F /* DimmedView.swift in Sources */,
 				0F2A2C6A2239C165003BDB2F /* PanContainerView.swift in Sources */,
+				CC49554F22FD26D000D168EB /* SolidDimmedView.swift in Sources */,
+				CCC8F4BB22FDC54E00F2A481 /* BlurDimmedView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -561,6 +581,7 @@
 			files = (
 				DC3B2EBA222A560A000C8A4A /* TransientAlertViewController.swift in Sources */,
 				743CABB42225FE7700634A5A /* UserGroupMemberPresentable.swift in Sources */,
+				CCC8F4BC22FDC6DF00F2A481 /* BlurDimmedView.swift in Sources */,
 				74C072A3220BA6E500124CE1 /* PanModalAnimator.swift in Sources */,
 				743CABB8222600C600634A5A /* UserGroupMemberCell.swift in Sources */,
 				743CABB62225FEEE00634A5A /* UserGroupHeaderPresentable.swift in Sources */,
@@ -571,6 +592,7 @@
 				DC3B2EBE222A58C9000C8A4A /* AlertView.swift in Sources */,
 				74C072A5220BA76D00124CE1 /* PanModalHeight.swift in Sources */,
 				94795C9B21F0335D008045A0 /* PanModalPresentationDelegate.swift in Sources */,
+				CC49555622FD36DF00D168EB /* GradientDimmedView.swift in Sources */,
 				943904F32226484F00859537 /* UserGroupStackedViewController.swift in Sources */,
 				74C072AA220BA82A00124CE1 /* UIViewController+PanModalPresenter.swift in Sources */,
 				943904ED2226366700859537 /* AlertViewController.swift in Sources */,
@@ -582,12 +604,14 @@
 				743CABB02225FC9F00634A5A /* UserGroupViewController.swift in Sources */,
 				DCC0EE7C21917F2500208DBC /* PanModalPresentable+Defaults.swift in Sources */,
 				94795C9D21F03368008045A0 /* PanContainerView.swift in Sources */,
+				CC49555322FD31E700D168EB /* PanModalBackgroundStyle.swift in Sources */,
 				74C072A7220BA78800124CE1 /* PanModalPresentable+LayoutHelpers.swift in Sources */,
 				DC139075216D9458007A3E64 /* DimmedView.swift in Sources */,
 				743CABD322265F2E00634A5A /* ProfileViewController.swift in Sources */,
 				DC139070216D9458007A3E64 /* PanModalPresentationAnimator.swift in Sources */,
 				944EBA2E227BB7F400C4C97B /* FullScreenNavController.swift in Sources */,
 				DCA741AE216D90410021F2F2 /* AppDelegate.swift in Sources */,
+				CC49555022FD270100D168EB /* SolidDimmedView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/PanModalTests.swift
+++ b/Tests/PanModalTests.swift
@@ -3,6 +3,7 @@
 //  PanModalTests
 //
 //  Created by Tosin Afolabi on 2/26/19.
+//  Updated by Nikita Nikitsky on 16/08/2019.
 //  Copyright © 2019 PanModal. All rights reserved.
 //
 
@@ -48,7 +49,7 @@ class PanModalTests: XCTestCase {
         XCTAssertEqual(vc.shortFormHeight, PanModalHeight.maxHeight)
         XCTAssertEqual(vc.longFormHeight, PanModalHeight.maxHeight)
         XCTAssertEqual(vc.springDamping, 0.8)
-        XCTAssertEqual(vc.backgroundAlpha, 0.7)
+        XCTAssertEqual(vc.backgroundStyle, PanModalBackgroundStyle.solid(color: .black, alpha: 0.7))
         XCTAssertEqual(vc.scrollIndicatorInsets, .zero)
         XCTAssertEqual(vc.anchorModalToLongForm, true)
         XCTAssertEqual(vc.allowsExtendedPanScrolling, false)


### PR DESCRIPTION
…al container (#18)

- Added solid color style with specified alpha
- Added color gradient style with specified start, end point, type of the gradient and alpha
- Added blur style with specified degree

###  Summary

PanModal by default provides the user with only one effect for the background. But sometimes this is not enough, as in our case. I noticed that users have a need for more flexible customization of the background of the pan modal container (for example, #18).
This change allows you to more flexibly customize the background of the pan modal container.
The PanModal user has the opportunity to choose one of the available background options of the pan modal container:
- solid color with specialized transparency;
- color gradient with a specialized beginning and end of the gradient, as well as type and transparency;
- bluer effect with a specialized degree.

Also, the PanModal user can implement the representation for the background of the pan domain of the container, for this he must write his own implementation for the DimmedViev protocol.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [x] I've written tests to cover the new code and functionality included in this PR.