### PR TITLE
Notify delegate method after the pan modal is dismissed

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -676,7 +676,9 @@ private extension PanModalPresentationController {
      */
     func dismissPresentedViewController() {
         presentable?.panModalWillDismiss()
-        presentedViewController.dismiss(animated: true, completion: nil)
+        presentedViewController.dismiss(animated: true) { [weak self] in
+            self?.presentable?.panModalDismissCompleted()
+        }
     }
 }
 

--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -677,7 +677,7 @@ private extension PanModalPresentationController {
     func dismissPresentedViewController() {
         presentable?.panModalWillDismiss()
         presentedViewController.dismiss(animated: true) { [weak self] in
-            self?.presentable?.panModalDismissCompleted()
+            self?.presentable?.panModalDidDismiss()
         }
     }
 }

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -112,7 +112,7 @@ public extension PanModalPresentable where Self: UIViewController {
 
     }
 
-    func panModalDismissCompleted() {
+    func panModalDidDismiss() {
 
     }
 }

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -112,4 +112,7 @@ public extension PanModalPresentable where Self: UIViewController {
 
     }
 
+    func panModalDismissCompleted() {
+
+    }
 }

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -212,4 +212,10 @@ public protocol PanModalPresentable: AnyObject {
      */
     func panModalWillDismiss()
 
+    /**
+     Notifies the delegate after the pan modal is dismissed.
+
+     Default value is an empty implementation.
+     */
+    func panModalDismissCompleted()
 }

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -217,5 +217,5 @@ public protocol PanModalPresentable: AnyObject {
 
      Default value is an empty implementation.
      */
-    func panModalDismissCompleted()
+    func panModalDidDismiss()
 }


### PR DESCRIPTION
###  Summary

Hi. I added `panModalDismissCompleted()` that is notified after the pan modal is dismissed.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [x] I've written tests to cover the new code and functionality included in this PR.
