### PR TITLE
Fix safe area layout issue

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -362,13 +362,22 @@ private extension PanModalPresentationController {
      Reduce height of presentedView so that it sits at the bottom of the screen
      */
     func adjustPresentedViewFrame() {
-
-        guard let frame = containerView?.frame
+        
+        guard let containerView = containerView
             else { return }
-
-        let adjustedSize = CGSize(width: frame.size.width, height: frame.size.height - anchoredYPosition)
+        let frame = containerView.frame
+        var adjustedSize : CGSize = .zero
+        
         panContainerView.frame.size = frame.size
-        presentedViewController.view.frame = CGRect(origin: .zero, size: adjustedSize)
+        if #available(iOS 11.0, *) {
+            let origin = containerView.safeAreaLayoutGuide.layoutFrame.origin
+            adjustedSize = CGSize(width: containerView.safeAreaLayoutGuide.layoutFrame.width, height:  containerView.safeAreaLayoutGuide.layoutFrame.height - anchoredYPosition)
+            presentedViewController.view.frame = CGRect(origin: origin, size: adjustedSize)
+        }
+        else{
+            adjustedSize = CGSize(width: frame.size.width, height: frame.size.height - anchoredYPosition)
+            presentedViewController.view.frame = CGRect(origin: .zero, size: adjustedSize)
+        }
     }
 
     /**


### PR DESCRIPTION
###  Summary

Fixing an issue where the PanModal's presentation view would be placed behind devices with notches when in landscape mode. 

| Before  | After |
| ------------- | ------------- |
| ![Before](https://user-images.githubusercontent.com/40777393/65252176-81593e00-dac6-11e9-8f7f-a047c82e85ee.png)  | ![After](https://user-images.githubusercontent.com/40777393/65252182-84542e80-dac6-11e9-9e28-3245d1b59f6a.png) |

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.