### PR TITLE
PanModal Portrait to Landscape Issue

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -226,16 +226,6 @@ public class PanModalPresentationController: UIPresentationController {
                 else { return }
 
             self.adjustPresentedViewFrame()
-            
-            let position = self.nearest(to: self.presentedView.frame.minY, inValues: [self.shortFormYPosition, self.longFormYPosition])
-            
-            if position == self.longFormYPosition {
-                self.transition(to: .longForm)
-                
-            } else if position == self.shortFormYPosition {
-                self.transition(to: .shortForm)
-            }
-
             if presentable.shouldRoundTopCorners {
                 self.addRoundedCorners(to: self.presentedView)
             }
@@ -376,7 +366,13 @@ private extension PanModalPresentationController {
             else { return }
 
         let adjustedSize = CGSize(width: frame.size.width, height: frame.size.height - anchoredYPosition)
+        let panFrame = panContainerView.frame
         panContainerView.frame.size = frame.size
+        
+        if ![shortFormYPosition, longFormYPosition].contains(panFrame.origin.y) {
+            adjust(toYPosition: panFrame.origin.y - panFrame.height + frame.height)
+        }
+        panContainerView.frame.origin.x = frame.origin.x
         presentedViewController.view.frame = CGRect(origin: .zero, size: adjustedSize)
     }
 

--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -226,6 +226,15 @@ public class PanModalPresentationController: UIPresentationController {
                 else { return }
 
             self.adjustPresentedViewFrame()
+            
+            let position = self.nearest(to: self.presentedView.frame.minY, inValues: [self.shortFormYPosition, self.longFormYPosition])
+            
+            if position == self.longFormYPosition {
+                self.transition(to: .longForm)
+                
+            } else if position == self.shortFormYPosition {
+                self.transition(to: .shortForm)
+            }
 
             if presentable.shouldRoundTopCorners {
                 self.addRoundedCorners(to: self.presentedView)


### PR DESCRIPTION
###  Summary
The goal of this PR is to fix an issue I was having where transitioning from portrait to landscape would cause a PanModal's view to disappear if its height was short. 

For example using the following code inside of the demo app for the `BasicViewController`:
```
var longFormHeight: PanModalHeight {
        return .contentHeight(200)
}
```

produced this result on rotation:
![Issue](https://user-images.githubusercontent.com/40777393/65400518-a7196800-dd90-11e9-9aef-c6d15d98b542.gif)

after the fix, this is what occurs: 
![Fix](https://user-images.githubusercontent.com/40777393/65400483-691c4400-dd90-11e9-8208-c1842d686a08.gif)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.