### PR TITLE
Added the ability to select a color for the background of the pan mod…

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -105,8 +105,8 @@ public class PanModalPresentationController: UIPresentationController {
      */
     private lazy var backgroundView: DimmedView = {
         let view: DimmedView
-        if let alpha = presentable?.backgroundAlpha {
-            view = DimmedView(dimAlpha: alpha)
+        if let color = presentable?.panModalBackgroundColor {
+            view = DimmedView(dimColor: color)
         } else {
             view = DimmedView()
         }

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -46,8 +46,8 @@ public extension PanModalPresentable where Self: UIViewController {
         return [.curveEaseInOut, .allowUserInteraction, .beginFromCurrentState]
     }
 
-    var backgroundAlpha: CGFloat {
-        return 0.7
+    var panModalBackgroundColor: UIColor {
+        return UIColor.black.withAlphaComponent(0.7)
     }
 
     var scrollIndicatorInsets: UIEdgeInsets {

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -86,13 +86,13 @@ public protocol PanModalPresentable: AnyObject {
     var transitionAnimationOptions: UIView.AnimationOptions { get }
 
     /**
-     The background view alpha.
+     The background view color.
 
      - Note: This is only utilized at the very start of the transition.
 
-     Default Value is 0.7.
-     */
-    var backgroundAlpha: CGFloat { get }
+     Default Value is black with alpha component 0.7.
+    */
+    var panModalBackgroundColor: UIColor { get }
 
     /**
      We configure the panScrollable's scrollIndicatorInsets interally so override this value

--- a/PanModal/View/DimmedView.swift
+++ b/PanModal/View/DimmedView.swift
@@ -31,12 +31,11 @@ public class DimmedView: UIView {
         didSet {
             switch dimState {
             case .max:
-                alpha = dimAlpha
+                alpha = 1.0
             case .off:
                 alpha = 0.0
             case .percent(let percentage):
-                let val = max(0.0, min(1.0, percentage))
-                alpha = dimAlpha * val
+                alpha = max(0.0, min(1.0, percentage))
             }
         }
     }
@@ -53,15 +52,12 @@ public class DimmedView: UIView {
         return UITapGestureRecognizer(target: self, action: #selector(didTapView))
     }()
 
-    private let dimAlpha: CGFloat
-
     // MARK: - Initializers
 
-    init(dimAlpha: CGFloat = 0.7) {
-        self.dimAlpha = dimAlpha
+    init(dimColor: UIColor = UIColor.black.withAlphaComponent(0.7)) {
         super.init(frame: .zero)
         alpha = 0.0
-        backgroundColor = .black
+        backgroundColor = dimColor
         addGestureRecognizer(tapGesture)
     }
 

--- a/Sample/View Controllers/Alert (Transient)/TransientAlertViewController.swift
+++ b/Sample/View Controllers/Alert (Transient)/TransientAlertViewController.swift
@@ -59,8 +59,8 @@ class TransientAlertViewController: AlertViewController {
         return true
     }
 
-    override var backgroundAlpha: CGFloat {
-        return 0.0
+    override var panModalBackgroundColor: UIColor {
+        return .clear
     }
 
     override var isUserInteractionEnabled: Bool {

--- a/Sample/View Controllers/Alert/AlertViewController.swift
+++ b/Sample/View Controllers/Alert/AlertViewController.swift
@@ -46,8 +46,8 @@ class AlertViewController: UIViewController, PanModalPresentable {
         return shortFormHeight
     }
 
-    var backgroundAlpha: CGFloat {
-        return 0.1
+    var panModalBackgroundColor: UIColor {
+        return UIColor.black.withAlphaComponent(0.1)
     }
 
     var shouldRoundTopCorners: Bool {

--- a/Tests/PanModalTests.swift
+++ b/Tests/PanModalTests.swift
@@ -48,7 +48,7 @@ class PanModalTests: XCTestCase {
         XCTAssertEqual(vc.shortFormHeight, PanModalHeight.maxHeight)
         XCTAssertEqual(vc.longFormHeight, PanModalHeight.maxHeight)
         XCTAssertEqual(vc.springDamping, 0.8)
-        XCTAssertEqual(vc.backgroundAlpha, 0.7)
+        XCTAssertEqual(vc.panModalBackgroundColor, UIColor.black.withAlphaComponent(0.7))
         XCTAssertEqual(vc.scrollIndicatorInsets, .zero)
         XCTAssertEqual(vc.anchorModalToLongForm, true)
         XCTAssertEqual(vc.allowsExtendedPanScrolling, false)


### PR DESCRIPTION
…al container

###  Summary

PanModal by default provides the user with only one color for the background. But sometimes this is not enough, as in our case. I noticed that users have a need for more flexible customization of the background of the pan modal container (for example, #18).
This change allows you to more flexibly customize the background of the pan modal container.
The PanModal user has the opportunity to choose color (UIColor) of the pan modal container.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [x] I've written tests to cover the new code and functionality included in this PR.
