### PR TITLE
Add allowTapToDismiss to PanModalPresentable

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -111,7 +111,9 @@ public class PanModalPresentationController: UIPresentationController {
             view = DimmedView()
         }
         view.didTap = { [weak self] _ in
-            self?.dismissPresentedViewController()
+            if self?.presentable?.allowsTapToDismiss == true {
+                self?.dismissPresentedViewController()
+            }
         }
         return view
     }()

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -72,6 +72,10 @@ public extension PanModalPresentable where Self: UIViewController {
         return true
     }
 
+    var allowsTapToDismiss: Bool {
+        return true
+    }
+
     var isUserInteractionEnabled: Bool {
         return true
     }

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -128,6 +128,13 @@ public protocol PanModalPresentable: AnyObject {
     var allowsDragToDismiss: Bool { get }
 
     /**
+     A flag to determine if dismissal should be initiated when tapping on the dimmed background view.
+
+     Default value is true.
+     */
+    var allowsTapToDismiss: Bool { get }
+
+    /**
      A flag to toggle user interactions on the container view.
 
      - Note: Return false to forward touches to the presentingViewController.

--- a/Tests/PanModalTests.swift
+++ b/Tests/PanModalTests.swift
@@ -53,6 +53,7 @@ class PanModalTests: XCTestCase {
         XCTAssertEqual(vc.anchorModalToLongForm, true)
         XCTAssertEqual(vc.allowsExtendedPanScrolling, false)
         XCTAssertEqual(vc.allowsDragToDismiss, true)
+        XCTAssertEqual(vc.allowsTapToDismiss, true)
         XCTAssertEqual(vc.isUserInteractionEnabled, true)
         XCTAssertEqual(vc.isHapticFeedbackEnabled, true)
         XCTAssertEqual(vc.shouldRoundTopCorners, false)


### PR DESCRIPTION
###  Summary

The goal of this PR is to add an additional point of configurability to the `PanModalPresentable` protocol. The `allowTapToDismiss` function will determine whether or not the presentable is dismissed when the dimmed background view is tapped.

Similar to `allowDragToDismiss`, this functionality can prevent the user from dismissing the presentable with an accidental tap. This is particularly important when they have unfinished work, or are in the middle of an important workflow.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [x] I've ~written~ added assertions to existing tests to cover the new code and functionality included in this PR.
