### PR TITLE
Make PanModalPresentationController subclassable

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -22,7 +22,7 @@ import UIKit
  By conforming to the PanModalPresentable protocol & overriding values
  the presented view can define its layout configuration & presentation.
  */
-public class PanModalPresentationController: UIPresentationController {
+open class PanModalPresentationController: UIPresentationController {
 
     /**
      Enum representing the possible presentation states


### PR DESCRIPTION
###  Summary

The PanModalPresentationController is public so it is not subclassable, so trying to do a custom pan modal presentation (see [here](https://github.com/slackhq/PanModal/pull/30#issuecomment-500160465)) that requires changes in the presentation controller is not possible. 

A possible scenario where this is could be used is trying to present a pan modal inside a form sheet on an iPad. Creating a subclass of PanModalPresentationController such as:
```
class EmbeddedPanModalPresentationController: PanModalPresentationController {
    	override var shouldPresentInFullscreen: Bool {
		return false
	}
}
```
would allow this customization easily.

This PR changes the PanModalPresentationController so it is `open` instead of `public` to allow subclassing for further customizations, without changing how foundational PanModal is.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.
