### PR TITLE
Add customizable drag indicator background color

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -133,11 +133,7 @@ open class PanModalPresentationController: UIPresentationController {
      */
     private lazy var dragIndicatorView: UIView = {
         let view = UIView()
-        if let color = presentable?.dragIndicatorBackgroundColor {
-            view.backgroundColor = color
-        } else {
-            view.backgroundColor = .lightGray
-        }
+        view.backgroundColor = presentable?.dragIndicatorBackgroundColor
         view.layer.cornerRadius = Constants.dragIndicatorSize.height / 2.0
         return view
     }()

--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -133,7 +133,11 @@ open class PanModalPresentationController: UIPresentationController {
      */
     private lazy var dragIndicatorView: UIView = {
         let view = UIView()
-        view.backgroundColor = .lightGray
+        if let color = presentable?.dragIndicatorBackgroundColor {
+            view.backgroundColor = color
+        } else {
+            view.backgroundColor = .lightGray
+        }
         view.layer.cornerRadius = Constants.dragIndicatorSize.height / 2.0
         return view
     }()

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -50,6 +50,10 @@ public extension PanModalPresentable where Self: UIViewController {
         return UIColor.black.withAlphaComponent(0.7)
     }
 
+    var dragIndicatorBackgroundColor: UIColor {
+        return UIColor.lightGray
+    }
+
     var scrollIndicatorInsets: UIEdgeInsets {
         let top = shouldRoundTopCorners ? cornerRadius : 0
         return UIEdgeInsets(top: CGFloat(top), left: 0, bottom: bottomLayoutOffset, right: 0)

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -97,7 +97,7 @@ public protocol PanModalPresentable: AnyObject {
     /**
      The drag indicator view color.
 
-     Default Value is light gray.
+     Default value is light gray.
     */
     var dragIndicatorBackgroundColor: UIColor { get }
 

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -95,6 +95,13 @@ public protocol PanModalPresentable: AnyObject {
     var panModalBackgroundColor: UIColor { get }
 
     /**
+     The drag indicator view color.
+
+     Default Value is light gray.
+    */
+    var dragIndicatorBackgroundColor: UIColor { get }
+
+    /**
      We configure the panScrollable's scrollIndicatorInsets interally so override this value
      to set custom insets.
 

--- a/Tests/PanModalTests.swift
+++ b/Tests/PanModalTests.swift
@@ -49,6 +49,7 @@ class PanModalTests: XCTestCase {
         XCTAssertEqual(vc.longFormHeight, PanModalHeight.maxHeight)
         XCTAssertEqual(vc.springDamping, 0.8)
         XCTAssertEqual(vc.panModalBackgroundColor, UIColor.black.withAlphaComponent(0.7))
+        XCTAssertEqual(vc.dragIndicatorBackgroundColor, UIColor.lightGray)
         XCTAssertEqual(vc.scrollIndicatorInsets, .zero)
         XCTAssertEqual(vc.anchorModalToLongForm, true)
         XCTAssertEqual(vc.allowsExtendedPanScrolling, false)


### PR DESCRIPTION
###  Summary

I needed to have drag indicator in other color than default light gray so I Added an ability to change drag indicator background color

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [x] I've written tests to cover the new code and functionality included in this PR.
