### PR TITLE
Xcode 10.3 Support

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -142,7 +142,7 @@ open class PanModalPresentationController: UIPresentationController {
     /**
      Override presented view to return the pan container wrapper
      */
-    public override var presentedView: UIView {
+    open override var presentedView: UIView {
         return panContainerView
     }
 
@@ -167,12 +167,12 @@ open class PanModalPresentationController: UIPresentationController {
 
     // MARK: - Lifecycle
 
-    override public func containerViewWillLayoutSubviews() {
+    override open func containerViewWillLayoutSubviews() {
         super.containerViewWillLayoutSubviews()
         configureViewLayout()
     }
 
-    override public func presentationTransitionWillBegin() {
+    override open func presentationTransitionWillBegin() {
 
         guard let containerView = containerView
             else { return }
@@ -192,7 +192,7 @@ open class PanModalPresentationController: UIPresentationController {
         })
     }
 
-    override public func dismissalTransitionWillBegin() {
+    override open func dismissalTransitionWillBegin() {
 
         guard let coordinator = presentedViewController.transitionCoordinator else {
             backgroundView.dimState = .off
@@ -210,7 +210,7 @@ open class PanModalPresentationController: UIPresentationController {
         })
     }
 
-    override public func presentationTransitionDidEnd(_ completed: Bool) {
+    override open func presentationTransitionDidEnd(_ completed: Bool) {
         if completed { return }
 
         backgroundView.removeFromSuperview()
@@ -219,7 +219,7 @@ open class PanModalPresentationController: UIPresentationController {
     /**
      Update presented view size in response to size class changes
      */
-    override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    override open func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
         coordinator.animate(alongsideTransition: { [weak self] _ in


### PR DESCRIPTION
###  Summary

When building PanModal 1.2.5 on Xcode 10.3, the build fails to issues with Access Control levels, namely:
```
Overriding property must be as accessible as the declaration it overrides
```

This is not an issue in Xcode 11.2 - I'm still digging into why it fails in Xcode 10.3, but elevating Access Control to `open` on below properties and methods fixes the issue.

Happy to hear suggestions or better fixes here 🙂 I may have missed something big - Should PanModal still support Xcode 10.3?

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [x] I've written tests to cover the new code and functionality included in this PR. (Needed in this case?)
