### PR TITLE
Fix Background dimming animation broken

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -367,7 +367,8 @@ private extension PanModalPresentationController {
         if ![shortFormYPosition, longFormYPosition].contains(panFrame.origin.y) {
             // if the container is already in the correct position, no need to adjust positioning
             // (rotations & size changes cause positioning to be out of sync)
-            adjust(toYPosition: panFrame.origin.y - panFrame.height + frame.height)
+            let yPosition = panFrame.origin.y - panFrame.height + frame.height
+            presentedView.frame.origin.y = max(yPosition, anchoredYPosition)
         }
         panContainerView.frame.origin.x = frame.origin.x
         presentedViewController.view.frame = CGRect(origin: .zero, size: adjustedSize)


### PR DESCRIPTION
###  Summary
Fix #72.
When the pan modal is presenting as not max-height `PanModalHeight` (or `topOffset` is not `0`), `backgroundView` is dimming immediately.
The issue has occurred from #53. If this commit is for device rotation, it has not to adjusts the `backgroundView` dim state.
In this PR, only the y position is changed.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.
