### PR TITLE
Change pan container backgroundColor

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -305,6 +305,12 @@ public extension PanModalPresentationController {
         configureScrollViewInsets()
     }
 
+    /**
+     Set a background color to the pan container view
+    */
+    func setPanContainerBackgroundColor(_ backgroundColor: UIColor) {
+        panContainerView.backgroundColor = backgroundColor
+    }
 }
 
 // MARK: - Presented View Layout Configuration

--- a/PanModal/Presentable/PanModalPresentable+UIViewController.swift
+++ b/PanModal/Presentable/PanModalPresentable+UIViewController.swift
@@ -58,4 +58,10 @@ public extension PanModalPresentable where Self: UIViewController {
         PanModalAnimator.animate(animationBlock, config: self, completion)
     }
 
+    /**
+     Set a background color to the pan container view
+     */
+    func setPanContainerBackgroundColor(_ backgroundColor: UIColor) {
+        presentedVC?.setPanContainerBackgroundColor(backgroundColor)
+    }
 }


### PR DESCRIPTION
###  Summary

Currently, the background color is synchronized internally, but it should be changeable so that it can be customized more flexibly.

I added `func setPanContainerBackgroundColor(_ backgroundColor: UIColor)` to allow set the background-color.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.
