### PR TITLE
Add completion block to present function

### DIFF
--- a/PanModal/Presenter/PanModalPresenter.swift
+++ b/PanModal/Presenter/PanModalPresenter.swift
@@ -29,7 +29,10 @@ protocol PanModalPresenter: AnyObject {
     /**
      Presents a view controller that conforms to the PanModalPresentable protocol
      */
-    func presentPanModal(_ viewControllerToPresent: PanModalPresentable.LayoutType, sourceView: UIView?, sourceRect: CGRect)
+    func presentPanModal(_ viewControllerToPresent: PanModalPresentable.LayoutType,
+                         sourceView: UIView?,
+                         sourceRect: CGRect,
+                         completion: (() -> Void)?)
 
 }
 #endif

--- a/PanModal/Presenter/UIViewController+PanModalPresenter.swift
+++ b/PanModal/Presenter/UIViewController+PanModalPresenter.swift
@@ -35,10 +35,14 @@ extension UIViewController: PanModalPresenter {
         - viewControllerToPresent: The view controller to be presented
         - sourceView: The view containing the anchor rectangle for the popover.
         - sourceRect: The rectangle in the specified view in which to anchor the popover.
+        - completion: The block to execute after the presentation finishes. You may specify nil for this parameter.
 
      - Note: sourceView & sourceRect are only required for presentation on an iPad.
      */
-    public func presentPanModal(_ viewControllerToPresent: PanModalPresentable.LayoutType, sourceView: UIView? = nil, sourceRect: CGRect = .zero) {
+    public func presentPanModal(_ viewControllerToPresent: PanModalPresentable.LayoutType,
+                                sourceView: UIView? = nil,
+                                sourceRect: CGRect = .zero,
+                                completion: (() -> Void)? = nil) {
 
         /**
          Here, we deliberately do not check for size classes. More info in `PanModalPresentationDelegate`
@@ -55,7 +59,7 @@ extension UIViewController: PanModalPresenter {
             viewControllerToPresent.transitioningDelegate = PanModalPresentationDelegate.default
         }
 
-        present(viewControllerToPresent, animated: true, completion: nil)
+        present(viewControllerToPresent, animated: true, completion: completion)
     }
 
 }


### PR DESCRIPTION
###  Summary

Add an optional completion block parameter to the `present()` function for code to be executed after presentation is completed. (just like the stock `UIViewController.present()`)

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.
