### PR TITLE
Replace deprecated bottomLayoutGuide

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -454,7 +454,11 @@ private extension PanModalPresentationController {
          Set the appropriate contentInset as the configuration within this class
          offsets it
          */
-        scrollView.contentInset.bottom = presentingViewController.bottomLayoutGuide.length
+        if #available(iOS 11.0, *) {
+            scrollView.contentInset.bottom = presentingViewController.view.safeAreaInsets.bottom
+        } else {
+            scrollView.contentInset.bottom = presentingViewController.bottomLayoutGuide.length
+        }
 
         /**
          As we adjust the bounds during `handleScrollViewTopBounce`


### PR DESCRIPTION
###  Summary

`bottomLayoutGuide` was deprecated since iOS11. 

### Requirements (place an `x` in each `[ ]`)

* [x ] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.
