### PR TITLE
Adding config to directly dismiss from long form

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -518,8 +518,10 @@ private extension PanModalPresentationController {
                 if velocity.y < 0 {
                     transition(to: .longForm)
 
-                } else if (nearest(to: presentedView.frame.minY, inValues: [longFormYPosition, containerView.bounds.height]) == longFormYPosition
-                    && presentedView.frame.minY < shortFormYPosition) || presentable?.allowsDragToDismiss == false {
+                } else if
+                    (nearest(to: presentedView.frame.minY, inValues: [longFormYPosition, containerView.bounds.height]) == longFormYPosition
+                    && presentedView.frame.minY < shortFormYPosition) || presentable?.allowsDragToDismiss == false
+                    && presentable?.shouldDismissWhenLongForm == false {
                     transition(to: .shortForm)
 
                 } else {

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -97,6 +97,10 @@ public extension PanModalPresentable where Self: UIViewController {
         return shouldRoundTopCorners
     }
 
+    var shouldDismissWhenLongForm: Bool {
+        return false
+    }
+
     func shouldRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {
         return true
     }

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -174,6 +174,14 @@ public protocol PanModalPresentable: AnyObject {
     var showDragIndicator: Bool { get }
 
     /**
+     A flag to determine if form dismiss from long form,
+     it does not stop in short form height when value is true.
+
+     Default value is false.
+     */
+    var shouldDismissWhenLongForm: Bool { get }
+
+    /**
      Asks the delegate if the pan modal should respond to the pan modal gesture recognizer.
      
      Return false to disable movement on the pan modal but maintain gestures on the presented view.

--- a/Sample/View Controllers/User Groups/UserGroupViewController.swift
+++ b/Sample/View Controllers/User Groups/UserGroupViewController.swift
@@ -32,8 +32,6 @@ class UserGroupViewController: UITableViewController, PanModalPresentable {
         UserGroupMemberPresentable(name: "Naida Schill", role: "Staff Engineer - Mobile DevXP", avatarBackgroundColor: #colorLiteral(red: 0.7215686275, green: 0.9098039216, blue: 0.5607843137, alpha: 1))
     ]
 
-    var isShortFormEnabled = true
-
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent
     }
@@ -94,7 +92,7 @@ class UserGroupViewController: UITableViewController, PanModalPresentable {
     }
 
     var shortFormHeight: PanModalHeight {
-        return isShortFormEnabled ? .contentHeight(300.0) : longFormHeight
+        return .contentHeight(300.0)
     }
 
     var scrollIndicatorInsets: UIEdgeInsets {
@@ -102,21 +100,12 @@ class UserGroupViewController: UITableViewController, PanModalPresentable {
         return UIEdgeInsets(top: headerView.frame.size.height, left: 0, bottom: bottomOffset, right: 0)
     }
 
-    var anchorModalToLongForm: Bool {
-        return false
+    var shouldDismissWhenLongForm: Bool {
+        return true
     }
 
     func shouldPrioritize(panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {
         let location = panModalGestureRecognizer.location(in: view)
         return headerView.frame.contains(location)
     }
-
-    func willTransition(to state: PanModalPresentationController.PresentationState) {
-        guard isShortFormEnabled, case .longForm = state
-            else { return }
-
-        isShortFormEnabled = false
-        panModalSetNeedsLayoutUpdate()
-    }
-
 }

--- a/Tests/PanModalTests.swift
+++ b/Tests/PanModalTests.swift
@@ -60,6 +60,7 @@ class PanModalTests: XCTestCase {
         XCTAssertEqual(vc.shouldRoundTopCorners, false)
         XCTAssertEqual(vc.showDragIndicator, false)
         XCTAssertEqual(vc.shouldRoundTopCorners, false)
+        XCTAssertEqual(vc.shouldDismissWhenLongForm, false)
         XCTAssertEqual(vc.cornerRadius, 8.0)
         XCTAssertEqual(vc.transitionDuration, PanModalAnimator.Constants.defaultTransitionDuration)
         XCTAssertEqual(vc.transitionAnimationOptions, [.curveEaseInOut, .allowUserInteraction, .beginFromCurrentState])


### PR DESCRIPTION
###  Summary

close https://github.com/slackhq/PanModal/issues/125

in sample code, `UserGroupViewController` has feature to dismiss directly from long form height. (Usually stops in short form height)
Therefore it is much better to have a config to switch this feature only toq add config value. (in this pull request I named as `shouldDismissWhenLongForm` )

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [x] I've written tests to cover the new code and functionality included in this PR.
