### PR TITLE
Add delegate to check if pan gesture should begin

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -817,6 +817,14 @@ private extension PanModalPresentationController {
 extension PanModalPresentationController: UIGestureRecognizerDelegate {
 
     /**
+     Asks the delegate if the pan modal should begin to track the pan gesture
+     */
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer == panGestureRecognizer else { return true }
+        return presentable?.shouldBeginPanGesture(panGestureRecognizer) ?? true
+    }
+    
+    /**
      Do not require any other gesture recognizers to fail
      */
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -96,6 +96,10 @@ public extension PanModalPresentable where Self: UIViewController {
     var showDragIndicator: Bool {
         return shouldRoundTopCorners
     }
+    
+    func shouldBeginPanGesture(_ panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {
+        return true
+    }
 
     func shouldRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {
         return true

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -174,6 +174,15 @@ public protocol PanModalPresentable: AnyObject {
     var showDragIndicator: Bool { get }
 
     /**
+     Asks the delegate if the pan modal should begin to track the pan gesture.
+     
+     Return false to not track the pan gesture and possibly let other observers track the gesture
+     
+     Default value is true.
+     */
+    func shouldBeginPanGesture(_ panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool
+    
+    /**
      Asks the delegate if the pan modal should respond to the pan modal gesture recognizer.
      
      Return false to disable movement on the pan modal but maintain gestures on the presented view.


### PR DESCRIPTION
###  Summary

This change allows to control if the pan gesture should begin or not. This is particularly important when your table view supports drag and drop or swipe to delete, since the pan gesture will conflict with the other table view gestures/touches.

The current delegate function `func shouldRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool` it is not enough to manage the pan gesture, because it's called too late during the gesture handling process.


Related issue/question:
https://github.com/slackhq/PanModal/issues/82

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.
