### PR TITLE
Remove warning message means that some properties was deprecated 

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -454,8 +454,11 @@ private extension PanModalPresentationController {
          Set the appropriate contentInset as the configuration within this class
          offsets it
          */
-        scrollView.contentInset.bottom = presentingViewController.bottomLayoutGuide.length
-
+        if #available(iOS 11.0, *) {
+            scrollView.contentInset.bottom = presentingViewController.view.safeAreaInsets.bottom
+        }else {
+            scrollView.contentInset.bottom = presentingViewController.bottomLayoutGuide.length
+        }
         /**
          As we adjust the bounds during `handleScrollViewTopBounce`
          we should assume that contentInsetAdjustmentBehavior will not be correct

--- a/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
+++ b/PanModal/Presentable/PanModalPresentable+LayoutHelpers.swift
@@ -112,8 +112,11 @@ extension PanModalPresentable where Self: UIViewController {
 
         guard let application = UIApplication.value(forKeyPath: #keyPath(UIApplication.shared)) as? UIApplication
             else { return nil }
-
-        return application.keyWindow?.rootViewController
+        if #available(iOS 13.0, *) {
+            return application.windows.first?.rootViewController
+        }else {
+            return application.keyWindow?.rootViewController
+        }
     }
 
 }

--- a/Sample/View Controllers/User Groups (Stacked)/StackedProfileViewController.swift
+++ b/Sample/View Controllers/User Groups (Stacked)/StackedProfileViewController.swift
@@ -89,7 +89,11 @@ class StackedProfileViewController: UIViewController, PanModalPresentable {
 
         roleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         roleLabel.topAnchor.constraint(equalTo: nameLabel.bottomAnchor, constant: 4.0).isActive = true
-        bottomLayoutGuide.topAnchor.constraint(greaterThanOrEqualTo: roleLabel.bottomAnchor).isActive = true
+        if #available(iOS 11.0, *) {
+            view.safeAreaLayoutGuide.bottomAnchor.constraint(greaterThanOrEqualTo: roleLabel.bottomAnchor).isActive = true
+        }else {
+            bottomLayoutGuide.topAnchor.constraint(greaterThanOrEqualTo: roleLabel.bottomAnchor).isActive = true
+        }
     }
 
     // MARK: - Pan Modal Presentable

--- a/Sample/View Controllers/User Groups/UserGroupViewController.swift
+++ b/Sample/View Controllers/User Groups/UserGroupViewController.swift
@@ -98,7 +98,12 @@ class UserGroupViewController: UITableViewController, PanModalPresentable {
     }
 
     var scrollIndicatorInsets: UIEdgeInsets {
-        let bottomOffset = presentingViewController?.bottomLayoutGuide.length ?? 0
+        var bottomOffset = CGFloat()
+        if #available(iOS 11.0, *) {
+            bottomOffset = presentingViewController?.view.safeAreaInsets.bottom ?? 0
+        }else {
+            bottomOffset = presentingViewController?.bottomLayoutGuide.length ?? 0
+        }
         return UIEdgeInsets(top: headerView.frame.size.height, left: 0, bottom: bottomOffset, right: 0)
     }
 


### PR DESCRIPTION
###  Summary
Remove warning message means that some properties was deprecated like "bottomLayoutGuide" "keyWindow"  
This warning occur when target's Deployment info iOS version is higher than 13.0.

Couple of month ago, I used to use this awesome library to my project. Thanks to getting PanModal, I could launch my first app.  After a long time, I return to this page and look for Issues if I handle that.  
This is ever my first PR and really trivial issue.
Fix #137
   

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.
