### PR TITLE
Remove appearance transitions called on presenting controller

### DIFF
--- a/PanModal/Animator/PanModalPresentationAnimator.swift
+++ b/PanModal/Animator/PanModalPresentationAnimator.swift
@@ -65,15 +65,11 @@ public class PanModalPresentationAnimator: NSObject {
     private func animatePresentation(transitionContext: UIViewControllerContextTransitioning) {
 
         guard
-            let toVC = transitionContext.viewController(forKey: .to),
-            let fromVC = transitionContext.viewController(forKey: .from)
+            let toVC = transitionContext.viewController(forKey: .to)
             else { return }
 
         let presentable = panModalLayoutType(from: transitionContext)
 
-        // Calls viewWillAppear and viewWillDisappear
-        fromVC.beginAppearanceTransition(false, animated: true)
-        
         // Presents the view in shortForm position, initially
         let yPos: CGFloat = presentable?.shortFormYPos ?? 0.0
 
@@ -93,7 +89,6 @@ public class PanModalPresentationAnimator: NSObject {
             panView.frame.origin.y = yPos
         }, config: presentable) { [weak self] didComplete in
             // Calls viewDidAppear and viewDidDisappear
-            fromVC.endAppearanceTransition()
             transitionContext.completeTransition(didComplete)
             self?.feedbackGenerator = nil
         }
@@ -105,12 +100,8 @@ public class PanModalPresentationAnimator: NSObject {
     private func animateDismissal(transitionContext: UIViewControllerContextTransitioning) {
 
         guard
-            let toVC = transitionContext.viewController(forKey: .to),
             let fromVC = transitionContext.viewController(forKey: .from)
             else { return }
-
-        // Calls viewWillAppear and viewWillDisappear
-        toVC.beginAppearanceTransition(true, animated: true)
         
         let presentable = panModalLayoutType(from: transitionContext)
         let panView: UIView = transitionContext.containerView.panContainerView ?? fromVC.view
@@ -120,7 +111,6 @@ public class PanModalPresentationAnimator: NSObject {
         }, config: presentable) { didComplete in
             fromVC.view.removeFromSuperview()
             // Calls viewDidAppear and viewDidDisappear
-            toVC.endAppearanceTransition()
             transitionContext.completeTransition(didComplete)
         }
     }


### PR DESCRIPTION
###  Summary

Fixes #139 

This better mimics how iOS handles `overFullScreen`/`overCurrentContext`/`pageSheet` style presentations where—since the presenting view controller is remaining visible and part of the view hierarchy—it does not call `view*Appear`/`view*Disappear` methods

Ultimately this is a behaviour breaking change though for anyone consuming the code and relying on the presenting controller getting appearance transition calls

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.
