### PR TITLE
Allow opting out of appearance transition callbacks on presenting view controller

### DIFF
--- a/PanModal/Animator/PanModalPresentationAnimator.swift
+++ b/PanModal/Animator/PanModalPresentationAnimator.swift
@@ -71,8 +71,11 @@ public class PanModalPresentationAnimator: NSObject {
 
         let presentable = panModalLayoutType(from: transitionContext)
 
-        // Calls viewWillAppear and viewWillDisappear
-        fromVC.beginAppearanceTransition(false, animated: true)
+        let isAppearanceTransition = presentable?.isAppearanceTransition ?? true
+        if isAppearanceTransition {
+            // Calls viewWillAppear and viewWillDisappear
+            fromVC.beginAppearanceTransition(false, animated: true)
+        }
         
         // Presents the view in shortForm position, initially
         let yPos: CGFloat = presentable?.shortFormYPos ?? 0.0
@@ -92,8 +95,10 @@ public class PanModalPresentationAnimator: NSObject {
         PanModalAnimator.animate({
             panView.frame.origin.y = yPos
         }, config: presentable) { [weak self] didComplete in
-            // Calls viewDidAppear and viewDidDisappear
-            fromVC.endAppearanceTransition()
+            if isAppearanceTransition {
+                // Calls viewDidAppear and viewDidDisappear
+                fromVC.endAppearanceTransition()
+            }
             transitionContext.completeTransition(didComplete)
             self?.feedbackGenerator = nil
         }

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -97,6 +97,10 @@ public extension PanModalPresentable where Self: UIViewController {
         return shouldRoundTopCorners
     }
 
+    var isAppearanceTransition: Bool {
+        return true
+    }
+
     func shouldRespond(to panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {
         return true
     }

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -174,6 +174,15 @@ public protocol PanModalPresentable: AnyObject {
     var showDragIndicator: Bool { get }
 
     /**
+     A flag to determine whether view lifecycle methods `view(Will|Did)(A|Disa)ppear` are called on the presenting view controller.
+
+     Since pan modal presentation does not remove the presenting view from the view hierarchy, it may not be desirable to call the relevant methods that are usually associated with removing the presenting view from the view hierarchy.
+
+     Default value is true.
+     */
+    var isAppearanceTransition: Bool { get }
+
+    /**
      Asks the delegate if the pan modal should respond to the pan modal gesture recognizer.
      
      Return false to disable movement on the pan modal but maintain gestures on the presented view.

--- a/Tests/PanModalTests.swift
+++ b/Tests/PanModalTests.swift
@@ -60,6 +60,7 @@ class PanModalTests: XCTestCase {
         XCTAssertEqual(vc.shouldRoundTopCorners, false)
         XCTAssertEqual(vc.showDragIndicator, false)
         XCTAssertEqual(vc.shouldRoundTopCorners, false)
+        XCTAssertEqual(vc.isAppearanceTransition, true)
         XCTAssertEqual(vc.cornerRadius, 8.0)
         XCTAssertEqual(vc.transitionDuration, PanModalAnimator.Constants.defaultTransitionDuration)
         XCTAssertEqual(vc.transitionAnimationOptions, [.curveEaseInOut, .allowUserInteraction, .beginFromCurrentState])


### PR DESCRIPTION
###  Summary

Allow `PanModalPresentable`s to opt out of having appearance transition callbacks (`viewWillAppear` etc.) called on the presenting view controller. (#47)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
* [x] I've written tests to cover the new code and functionality included in this PR.

### Notes

`testPresentableYValues` fails for me locally, but it wasn't relevant to this PR :)

In #47, there's a request for a reason to avoid these calls. In our case, we're showing the modal with a blurred background, and we wanted the presenting view controller's content to continue updating (we stop updating in viewDidDisappear). I went with a property on `PanModalPresentable` to avoid breaking existing library users, who may rely on the current behavior.

Thank you for sharing PanModal!