### PR TITLE
Add  background interaction

### DIFF
--- a/PanModal/Presentable/PanModalBackgroundInteraction.swift
+++ b/PanModal/Presentable/PanModalBackgroundInteraction.swift
@@ -1,0 +1,25 @@
+//
+//  PanModalBackgroundInteraction.swift
+//
+//
+//  Created by Nuno Tavares on 07/02/2022.
+//
+
+import Foundation
+
+/** Describes the user interaction events that are triggered as the user taps the background */
+public enum PanModalBackgroundInteraction: Equatable {
+    
+    /** Taps dismiss the modal immediately */
+    case dismiss
+    
+    /** Touches are forwarded to the lower window (In most cases it would be the application main window that will handle it */
+    case forwardToParent
+    
+    /** Touches are forwarded to the first view controller that is not a `PanModalPresentable`*/
+    case forwardToRoot
+    
+    /** Absorbs touches. The modal does nothing (Swallows the touch) */
+    case none
+    
+}

--- a/PanModal/Presentable/PanModalPresentable+Defaults.swift
+++ b/PanModal/Presentable/PanModalPresentable+Defaults.swift
@@ -80,6 +80,10 @@ public extension PanModalPresentable where Self: UIViewController {
     var allowsTapToDismiss: Bool {
         return true
     }
+    
+    var backgroundInteraction: PanModalBackgroundInteraction {
+        return allowsTapToDismiss ? .dismiss : .none
+    }
 
     var isUserInteractionEnabled: Bool {
         return true

--- a/PanModal/Presentable/PanModalPresentable.swift
+++ b/PanModal/Presentable/PanModalPresentable.swift
@@ -141,6 +141,13 @@ public protocol PanModalPresentable: AnyObject {
      Default value is true.
      */
     var allowsTapToDismiss: Bool { get }
+    
+    /**
+     Describes what happens when the user interacts the background view.
+     
+     Default value is .dismiss.
+     */
+    var backgroundInteraction: PanModalBackgroundInteraction { get }
 
     /**
      A flag to toggle user interactions on the container view.

--- a/PanModal/View/DimmedView.swift
+++ b/PanModal/View/DimmedView.swift
@@ -40,11 +40,24 @@ public class DimmedView: UIView {
             }
         }
     }
+    
+    /**
+     The closure to be executed on hitTest
+     */
+    var hitTestHandler: ((_ point: CGPoint, _ event: UIEvent?) -> UIView?)?
 
     /**
      The closure to be executed when a tap occurs
      */
-    var didTap: ((_ recognizer: UIGestureRecognizer) -> Void)?
+    var didTap: ((_ recognizer: UIGestureRecognizer) -> Void)? {
+        didSet {
+            if self.didTap != nil {
+                addGestureRecognizer(tapGesture)
+            } else {
+                removeGestureRecognizer(tapGesture)
+            }
+        }
+    }
 
     /**
      Tap gesture recognizer
@@ -67,6 +80,10 @@ public class DimmedView: UIView {
     }
 
     // MARK: - Event Handlers
+    
+    public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        return self.hitTestHandler?(point, event) ?? super.hitTest(point, with: event)
+    }
 
     @objc private func didTapView() {
         didTap?(tapGesture)

--- a/PanModalDemo.xcodeproj/project.pbxproj
+++ b/PanModalDemo.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		0F2A2C682239C15D003BDB2F /* UIViewController+PanModalPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C072A9220BA82A00124CE1 /* UIViewController+PanModalPresenter.swift */; };
 		0F2A2C692239C162003BDB2F /* DimmedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC13906E216D9458007A3E64 /* DimmedView.swift */; };
 		0F2A2C6A2239C165003BDB2F /* PanContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94795C9C21F03368008045A0 /* PanContainerView.swift */; };
+		114937B227B131700052315B /* PanModalBackgroundInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114937B127B131700052315B /* PanModalBackgroundInteraction.swift */; };
+		114937B327B131B50052315B /* PanModalBackgroundInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 114937B127B131700052315B /* PanModalBackgroundInteraction.swift */; };
 		743CABB02225FC9F00634A5A /* UserGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABAF2225FC9F00634A5A /* UserGroupViewController.swift */; };
 		743CABB22225FD1100634A5A /* UserGroupHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABB12225FD1100634A5A /* UserGroupHeaderView.swift */; };
 		743CABB42225FE7700634A5A /* UserGroupMemberPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 743CABB32225FE7700634A5A /* UserGroupMemberPresentable.swift */; };
@@ -93,6 +95,7 @@
 		0F2A2C512239C119003BDB2F /* PanModal.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PanModal.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0F2A2C532239C119003BDB2F /* PanModal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PanModal.h; sourceTree = "<group>"; };
 		0F2A2C542239C119003BDB2F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		114937B127B131700052315B /* PanModalBackgroundInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanModalBackgroundInteraction.swift; sourceTree = "<group>"; };
 		743CABAF2225FC9F00634A5A /* UserGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserGroupViewController.swift; sourceTree = "<group>"; };
 		743CABB12225FD1100634A5A /* UserGroupHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserGroupHeaderView.swift; sourceTree = "<group>"; };
 		743CABB32225FE7700634A5A /* UserGroupMemberPresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserGroupMemberPresentable.swift; sourceTree = "<group>"; };
@@ -304,6 +307,7 @@
 				DCC0EE7B21917F2500208DBC /* PanModalPresentable+Defaults.swift */,
 				DC139069216D9458007A3E64 /* PanModalPresentable+UIViewController.swift */,
 				74C072A6220BA78800124CE1 /* PanModalPresentable+LayoutHelpers.swift */,
+				114937B127B131700052315B /* PanModalBackgroundInteraction.swift */,
 			);
 			path = Presentable;
 			sourceTree = "<group>";
@@ -540,6 +544,7 @@
 				0F2A2C642239C14E003BDB2F /* PanModalPresentable+Defaults.swift in Sources */,
 				0F2A2C652239C151003BDB2F /* PanModalPresentable+UIViewController.swift in Sources */,
 				0F2A2C662239C153003BDB2F /* PanModalPresentable+LayoutHelpers.swift in Sources */,
+				114937B227B131700052315B /* PanModalBackgroundInteraction.swift in Sources */,
 				0F2A2C672239C157003BDB2F /* PanModalPresenter.swift in Sources */,
 				0F2A2C682239C15D003BDB2F /* UIViewController+PanModalPresenter.swift in Sources */,
 				0F2A2C692239C162003BDB2F /* DimmedView.swift in Sources */,
@@ -587,6 +592,7 @@
 				743CABD322265F2E00634A5A /* ProfileViewController.swift in Sources */,
 				DC139070216D9458007A3E64 /* PanModalPresentationAnimator.swift in Sources */,
 				944EBA2E227BB7F400C4C97B /* FullScreenNavController.swift in Sources */,
+				114937B327B131B50052315B /* PanModalBackgroundInteraction.swift in Sources */,
 				DCA741AE216D90410021F2F2 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sample/View Controllers/User Groups/UserGroupViewController.swift
+++ b/Sample/View Controllers/User Groups/UserGroupViewController.swift
@@ -84,6 +84,7 @@ class UserGroupViewController: UITableViewController, PanModalPresentable {
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        presentPanModal(UserGroupViewController())
         tableView.deselectRow(at: indexPath, animated: true)
     }
 
@@ -105,6 +106,8 @@ class UserGroupViewController: UITableViewController, PanModalPresentable {
     var anchorModalToLongForm: Bool {
         return false
     }
+    
+    var backgroundInteraction: PanModalBackgroundInteraction { .forwardToRoot }
 
     func shouldPrioritize(panModalGestureRecognizer: UIPanGestureRecognizer) -> Bool {
         let location = panModalGestureRecognizer.location(in: view)


### PR DESCRIPTION
- Add background interaction to make it possible to interact with the calendar view even when the bottom sheet is open;
- Add `.fowardToRoot` to propagate touches to the first non-`PanModalPresentable` view controller in the presentation stack;
- Convert touch point to the appropriate coordinates in the correct view;