### PR TITLE
Update PanModalPresentationController.swift

### DIFF
--- a/PanModal.podspec
+++ b/PanModal.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.author           = { 'slack' => 'opensource@slack.com' }
   s.source           = { :git => 'https://github.com/slackhq/PanModal.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/slackhq'
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '9.0'
   s.swift_version = '5.0'
   s.source_files = 'PanModal/**/*.{swift,h,m}'
 end

--- a/PanModal/Animator/PanModalPresentationAnimator.swift
+++ b/PanModal/Animator/PanModalPresentationAnimator.swift
@@ -42,8 +42,15 @@ public class PanModalPresentationAnimator: NSObject {
     /**
      Haptic feedback generator (during presentation)
      */
-    private var feedbackGenerator: UISelectionFeedbackGenerator?
-
+    private var _feedbackGenerator: Any? = nil
+    @available(iOS 10.0, *)
+    fileprivate var feedbackGenerator: UISelectionFeedbackGenerator? {
+        set {
+            _feedbackGenerator = newValue
+        } get {
+            return _feedbackGenerator as? UISelectionFeedbackGenerator
+        }
+    }
     // MARK: - Initializers
 
     required public init(transitionStyle: TransitionStyle) {
@@ -54,8 +61,12 @@ public class PanModalPresentationAnimator: NSObject {
          Prepare haptic feedback, only during the presentation state
          */
         if case .presentation = transitionStyle {
-            feedbackGenerator = UISelectionFeedbackGenerator()
-            feedbackGenerator?.prepare()
+            if #available(iOS 10.0, *) {
+                feedbackGenerator = UISelectionFeedbackGenerator()
+                feedbackGenerator?.prepare()
+            } else {
+                // Fallback on earlier versions
+            }
         }
     }
 
@@ -86,7 +97,11 @@ public class PanModalPresentationAnimator: NSObject {
 
         // Haptic feedback
         if presentable?.isHapticFeedbackEnabled == true {
-            feedbackGenerator?.selectionChanged()
+            if #available(iOS 10.0, *) {
+                feedbackGenerator?.selectionChanged()
+            } else {
+                // Fallback on earlier versions
+            }
         }
 
         PanModalAnimator.animate({
@@ -95,7 +110,11 @@ public class PanModalPresentationAnimator: NSObject {
             // Calls viewDidAppear and viewDidDisappear
             fromVC.endAppearanceTransition()
             transitionContext.completeTransition(didComplete)
-            self?.feedbackGenerator = nil
+            if #available(iOS 10.0, *) {
+                self?.feedbackGenerator = nil
+            } else {
+                // Fallback on earlier versions
+            }
         }
     }
 

--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -197,6 +197,13 @@ open class PanModalPresentationController: UIPresentationController {
 
         backgroundView.removeFromSuperview()
     }
+ 
+    open override func containerViewDidLayoutSubviews() {
+        super.containerViewDidLayoutSubviews()
+        if self.presentable?.shouldRoundTopCorners ?? false {
+            self.addRoundedCorners(to: self.presentedView)
+        }
+    }
 
     override public func dismissalTransitionWillBegin() {
         presentable?.panModalWillDismiss()

--- a/PanModalDemo.xcodeproj/project.pbxproj
+++ b/PanModalDemo.xcodeproj/project.pbxproj
@@ -832,7 +832,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 6UF7FN999R;
 				INFOPLIST_FILE = "$(SRCROOT)/Sample/Resources/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -853,7 +853,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 6UF7FN999R;
 				INFOPLIST_FILE = "$(SRCROOT)/Sample/Resources/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Sample/View Controllers/Alert (Transient)/TransientAlertViewController.swift
+++ b/Sample/View Controllers/Alert (Transient)/TransientAlertViewController.swift
@@ -26,10 +26,19 @@ class TransientAlertViewController: AlertViewController {
 
     private func startTimer() {
         timer?.invalidate()
-        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-            self?.countdown -= 1
-            self?.updateMessage()
+        if #available(iOS 10.0, *) {
+            timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+                self?.onTimer()
+            }
+        } else {
+            // Fallback on earlier versions
+            timer = Timer.scheduledTimer(timeInterval: 1.0, target: self, selector: #selector(onTimer), userInfo: nil, repeats: true)
         }
+    }
+    
+    @objc func onTimer() {
+        self.countdown -= 1
+        self.updateMessage()
     }
 
     @objc func updateMessage() {


### PR DESCRIPTION
###  Summary

```swift
self.panModalSetNeedsLayoutUpdate()
self.panModalTransition(to: .longForm)
```
After shouldRoundTopCorners is set, if the height of the view is refreshed, the content of the page will be completely masked because the width and height of the page are 0 when the corners are drawn

So just need to redraw after containerViewDidLayoutSubviews rounded corners

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [x] I've written tests to cover the new code and functionality included in this PR.
