### PR TITLE
Fix crash on presenting pan modal over pan modal

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -759,8 +759,11 @@ private extension PanModalPresentationController {
      Halts the scroll of a given scroll view & anchors it at the `scrollViewYOffset`
      */
     func haltScrolling(_ scrollView: UIScrollView) {
-        scrollView.setContentOffset(CGPoint(x: 0, y: scrollViewYOffset), animated: false)
-        scrollView.showsVerticalScrollIndicator = false
+        let point = CGPoint(x: 0, y: scrollViewYOffset.rounded())
+        if presentedViewController.isPanModalPresented && point != scrollView.contentOffset {
+            scrollView.setContentOffset(point, animated: false)
+            scrollView.showsVerticalScrollIndicator = false
+        }
     }
 
     /**

--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -759,7 +759,7 @@ private extension PanModalPresentationController {
      Halts the scroll of a given scroll view & anchors it at the `scrollViewYOffset`
      */
     func haltScrolling(_ scrollView: UIScrollView) {
-        let point = CGPoint(x: 0, y: scrollViewYOffset.rounded())
+        let point = CGPoint(x: 0, y: min(scrollViewYOffset.rounded(), scrollView.contentSize.height))
         if presentedViewController.isPanModalPresented && point != scrollView.contentOffset {
             scrollView.setContentOffset(point, animated: false)
             scrollView.showsVerticalScrollIndicator = false

--- a/PanModal/Presenter/UIViewController+PanModalPresenter.swift
+++ b/PanModal/Presenter/UIViewController+PanModalPresenter.swift
@@ -24,7 +24,8 @@ extension UIViewController: PanModalPresenter {
      the presentationController is referenced here and called too early resulting in
      a strong reference to this view controller and in turn, creating a memory leak.
      */
-    public var isPanModalPresented: Bool {
+    @objc
+    open var isPanModalPresented: Bool {
         return (transitioningDelegate as? PanModalPresentationDelegate) != nil
     }
 


### PR DESCRIPTION
###  Summary

Fix crash on presenting pan modal over pan modal
Related issues:
https://github.com/slackhq/PanModal/issues/157
https://github.com/slackhq/PanModal/issues/142

### Requirements (place an `x` in each `[ ]`)

* [ x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ x] I've written tests to cover the new code and functionality included in this PR.
