### PR TITLE
Make PanModalPresentationController's methods open so they can be overriden by a subclass

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -167,12 +167,12 @@ open class PanModalPresentationController: UIPresentationController {
 
     // MARK: - Lifecycle
 
-    override public func containerViewWillLayoutSubviews() {
+    override open func containerViewWillLayoutSubviews() {
         super.containerViewWillLayoutSubviews()
         configureViewLayout()
     }
 
-    override public func presentationTransitionWillBegin() {
+    override open func presentationTransitionWillBegin() {
 
         guard let containerView = containerView
             else { return }
@@ -192,13 +192,13 @@ open class PanModalPresentationController: UIPresentationController {
         })
     }
 
-    override public func presentationTransitionDidEnd(_ completed: Bool) {
+    override open func presentationTransitionDidEnd(_ completed: Bool) {
         if completed { return }
 
         backgroundView.removeFromSuperview()
     }
 
-    override public func dismissalTransitionWillBegin() {
+    override open func dismissalTransitionWillBegin() {
         presentable?.panModalWillDismiss()
 
         guard let coordinator = presentedViewController.transitionCoordinator else {
@@ -217,7 +217,7 @@ open class PanModalPresentationController: UIPresentationController {
         })
     }
 
-    override public func dismissalTransitionDidEnd(_ completed: Bool) {
+    override open func dismissalTransitionDidEnd(_ completed: Bool) {
         if !completed { return }
         
         presentable?.panModalDidDismiss()
@@ -226,7 +226,7 @@ open class PanModalPresentationController: UIPresentationController {
     /**
      Update presented view size in response to size class changes
      */
-    override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+    override open func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
         coordinator.animate(alongsideTransition: { [weak self] _ in


### PR DESCRIPTION
###  Summary

Let's say I want to create a presentation controller that has a similar behaviour as `PanModalPresentationController`. I want to be able to create a `PanModalPresentationController`'s subclass and make some adjustments.
For example I want to create a `DrawerPresentationController` that inherits from `PanModalPresentationController` and override `containerViewWillLayoutSubviews` in order to be able to add more views to the container (e.g. close button that closes a drawer once tapped).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [ ] I've written tests to cover the new code and functionality included in this PR.
