### PR TITLE
Fix ios 17.1+ issue

### DIFF
--- a/PanModal/Controller/PanModalPresentationController.swift
+++ b/PanModal/Controller/PanModalPresentationController.swift
@@ -176,7 +176,9 @@ open class PanModalPresentationController: UIPresentationController {
 
         guard let containerView = containerView
             else { return }
-
+        if self.panContainerView.frame == .zero {
+            self.adjustPresentedViewFrame()
+        }
         layoutBackgroundView(in: containerView)
         layoutPresentedView(in: containerView)
         configureScrollViewInsets()


### PR DESCRIPTION
###  Summary

Fix for ios 17.1+ versions when displaying certain UIViewControllers where `containerView` has not yet been set.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [x] I've written tests to cover the new code and functionality included in this PR.
