### PR TITLE
Attempt to fix ios 17.2 issues

### DIFF
--- a/PanModal/Delegate/PanModalPresentationDelegate.swift
+++ b/PanModal/Delegate/PanModalPresentationDelegate.swift
@@ -52,7 +52,7 @@ extension PanModalPresentationDelegate: UIViewControllerTransitioningDelegate {
      Changes in size class during presentation are handled via the adaptive presentation delegate
      */
     public func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
-        let controller = PanModalPresentationController(presentedViewController: presented, presenting: presenting)
+        let controller = PanModalPresentationController(presentedViewController: presented, presenting: presenting ?? source)
         controller.delegate = self
         return controller
     }


### PR DESCRIPTION
###  Summary

Fix for iOS 17.1+ versions when using PanModal for view controller containers (UINavigationController, UIPageViewController, etc). In this case `containerView` inside `PanModalPresentationController` is nil and it breaks the logic, and as a result the bottom sheet is not displayed.

As we show bottom sheets, I think we always should have a[ presenting view controller](https://developer.apple.com/documentation/uikit/uipresentationcontroller/1618328-init). 
So the solution is to pass a source view controller in case of presenting view controller is not determined by OS.

Please note that there are cases when  [presenting view controller != source view controller](https://developer.apple.com/documentation/uikit/uiviewcontrollertransitioningdelegate/1622057-presentationcontroller), but I think for the case of this library it doesn't make much difference.

Tested on iPhone and iPad running on iOS 17.2.

### Requirements (place an `x` in each `[ ]`)

* [ x] I've read and understood the [Contributing Guidelines](https://github.com/slackhq/PanModal/blob/master/CONTRIBUTING.md) and have done my best effort to follow them.
* [x ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

* [x ] I've written tests to cover the new code and functionality included in this PR.
